### PR TITLE
Sampler API POC

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,3 @@
+[
+  {":0:unknown_function Function ExUnit.Assertions.flunk/1 does not exist."}
+]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,8 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [
+    assert_dispatched: 3,
+    assert_dispatched: 4
+  ]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,6 +3,7 @@
   inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
   locals_without_parens: [
     assert_dispatched: 3,
-    assert_dispatched: 4
+    assert_dispatched: 4,
+    assert_dispatch: 4
   ]
 ]

--- a/lib/telemetry_sampler.ex
+++ b/lib/telemetry_sampler.ex
@@ -22,9 +22,8 @@ defmodule Telemetry.Sampler do
 
   ## Starting and stopping
 
-  You can start the Sampler using the `start/1` and `start_link/1` functions. Sampler can be alaso
-  started as a part of your supervision tree, using both the old-style and the new-style child
-  specifications:
+  You can start the Sampler using the `start_link/1` function. Sampler can be alaso started as a
+  part of your supervision tree, using both the old-style and the new-style child specifications:
 
       # pre Elixir 1.5.0
       children = [Supervisor.Spec.worker(Telemetry.Sampler, [[period: 5000]])]
@@ -110,17 +109,6 @@ defmodule Telemetry.Sampler do
   def start_link(options \\ []) when is_list(options) do
     {sampler_opts, gen_server_opts} = parse_options!(options)
     GenServer.start_link(__MODULE__, sampler_opts, gen_server_opts)
-  end
-
-  @doc """
-  Starts a Sampler process.
-
-  For description of possible options see documentation for `start_link/1`.
-  """
-  @spec start(options()) :: GenServer.on_start()
-  def start(options \\ []) when is_list(options) do
-    {sampler_opts, gen_server_opts} = parse_options!(options)
-    GenServer.start(__MODULE__, sampler_opts, gen_server_opts)
   end
 
   @doc """

--- a/lib/telemetry_sampler.ex
+++ b/lib/telemetry_sampler.ex
@@ -1,5 +1,399 @@
 defmodule Telemetry.Sampler do
   @moduledoc """
-  Allows to periodically gather measurements and publish them as `Telemetry` events
+  Allows to periodically collect measurements and publish them as `Telemetry` events.
+
+  ## Measurement specifications
+
+  Measurement specifications (later "specs") describe how the measurement should be performed and
+  what event should be emitted once the mesured value is collected. There are three possible values
+  for measurement spec:
+
+  1. An MFA tuple returning a single sample or a list of samples. Sample is an opaque data structure
+     which consists of event name, collected measurement value and event metadata. Samples can
+     be constructed using the `sample/3` function. Sampler will dispatch a `Telemetry` event
+     for each sample returned by the MFA invokation.
+  2. An atom representing a name of the function from `Telemetry.Sampler.VM` module. See documentation
+     for `Telemetry.Sampler.VM` module to learn about allowed values. Atom measurement spec is
+     equivalent to `{Telemetry.Sampler.VM, atom, []}` MFA spec.
+  3. A tuple, where the first element is event name and the second element is an MFA returning a
+     *number*. In this case, Sampler will dispatch an event with given name and value returned
+     by the MFA invokation; event metadata will be always empty.
+
+  If the invokation of MFA returns an invalid value (i.e. it should return a sample but doesn't,
+  or it should return a number but doesn't), the spec is removed from the list and the error
+  is logged.
+
+  ## Starting and stopping
+
+  You can start the Sampler using the `start/1` and `start_link/1` functions. Sampler can be alaso
+  started as a part of your supervision tree, using both the old-style and the new-style child
+  specifications:
+
+      # pre Elixir 1.5.0
+      children = [Supervisor.Spec.worker(Telemetry.Sampler, [[period: 5000]])]
+
+      # post Elixir 1.5.0
+      children = [{Telemetry.Sampler, [period: 5000]}]
+
+      Supervisor.start_link(children, [strategy: :one_for_one]
+
+  You can start as many Samplers as you wish, but generally you shouldn't need to do it, unless
+  you know that it's not keeping up with collecting all specified measurements.
+
+  By default Sampler starts with a set of measurement specs related to Erlang virtual machine.
+  Providing `:measurements` option overrides the default specs, although you can use the
+  `default_specs/0` function to keep the defaults and add your own measurements:
+
+      Telemetry.Sampler.start_link(
+          measurements: Telemetry.Sampler.default_specs() ++ [{MeasurementSpecs, :session_count, []}])
+
+  ## VM measurements
+
+  See documentation for `Telemetry.Sampler.VM` module to learn what VM metrics can be collected
+  by Sampler.
   """
+
+  use GenServer
+
+  require Logger
+
+  @default_period 10_000
+
+  @type t :: GenServer.server()
+  @type options :: [option()]
+  @type option ::
+          {:name, GenServer.name()}
+          | {:period, period()}
+          | {:measurements, [measurement_spec()]}
+  @type period :: pos_integer()
+  @type measurement_spec :: atom() | mfa() | {Telemetry.event_name(), mfa()}
+  @opaque sample() ::
+            {:sample, Telemetry.event_name(), Telemetry.event_value(), Telemetry.event_metadata()}
+
+  ## API
+  @doc """
+  Returns a child specifiction for Sampler.
+
+  It accepts `nil` or `t:options/0` as an argument, meaning that it's valid to start it under the
+  supervisor as follows:
+
+      alias Telemetry.Sampler
+      # use default options
+      Supervisor.start_link([Sampler], supervisor_opts) # use default options
+      # customize options
+      Supervisor.start_link([{Sampler, period: 10_000}], supervisor_opts)
+      # modify the child spec
+      Supervisor.start_link(Supervisor.child_spec(Sampler, id: MySampler), supervisor_opts)
+  """
+  # Uncomment when dropping support for 1.4.x releases.
+  # @spec child_spec(term()) :: Supervisor.child_spec()
+  def child_spec(term)
+
+  def child_spec(nil) do
+    child_spec([])
+  end
+
+  def child_spec(options) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [options]}
+    }
+  end
+
+  @doc """
+  Starts a Sampler linked to the calling process.
+
+  Useful for starting Samplers as a part of a supervision tree.
+
+  ### Options
+
+  * `:measurements` - a list of measurements specs used by Sampler. For description of possible values
+    see "Measurement specifications" section of `Sampler` module documentation;
+  * `:period` - time period before performing the same measurement again, in milliseconds. Default
+    value is #{@default_period} ms;
+  * `:name` - the name of the Sampler process. See "Name Registragion" section of `GenServer`
+    documentation for information about allowed values.
+  """
+  @spec start_link(options()) :: GenServer.on_start()
+  def start_link(options \\ []) when is_list(options) do
+    {sampler_opts, gen_server_opts} = parse_options!(options)
+    GenServer.start_link(__MODULE__, sampler_opts, gen_server_opts)
+  end
+
+  @doc """
+  Starts a Sampler process.
+
+  For description of possible options see documentation for `start_link/1`.
+  """
+  @spec start(options()) :: GenServer.on_start()
+  def start(options \\ []) when is_list(options) do
+    {sampler_opts, gen_server_opts} = parse_options!(options)
+    GenServer.start(__MODULE__, sampler_opts, gen_server_opts)
+  end
+
+  @doc """
+  Stops the `sampler` with specified `reason`.
+
+  See documentation for `GenServer.stop/3` to learn more about the behaviour of this function.
+  """
+  @spec stop(t(), reason :: term(), timeout()) :: :ok
+  def stop(sampler, reason \\ :normal, timeout \\ :infinity) do
+    GenServer.stop(sampler, reason, timeout)
+  end
+
+  @doc """
+  Returns a list of measurement specs used by the sampler.
+  """
+  @spec list_specs(t()) :: [measurement_spec()]
+  def list_specs(sampler) do
+    GenServer.call(sampler, :get_specs)
+  end
+
+  @doc """
+  Returns list of specs used by the Sampler by default.
+  """
+  @spec default_specs() :: [measurement_spec()]
+  def default_specs() do
+    [:memory]
+  end
+
+  @doc """
+  Returns a single measurement sample.
+
+  This function should be used by measurement spec MFAs.
+  """
+  @spec sample(Telemetry.event_name(), Telemetry.event_value(), Telemetry.event_metadata()) ::
+          sample()
+  def sample(event, value, metadata) do
+    {:sample, event, value, metadata}
+  end
+
+  ## GenServer callbacks
+
+  @impl true
+  def init(options) do
+    state = %{
+      specs: Keyword.fetch!(options, :measurements),
+      period: Keyword.fetch!(options, :period)
+    }
+
+    schedule_collection(0)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:collect, state) do
+    new_specs =
+      state.specs
+      |> collect_measurements()
+      |> dispatch_events_and_filter_misbehaving()
+
+    schedule_collection(state.period)
+    {:noreply, %{state | specs: new_specs}}
+  end
+
+  @impl true
+  def handle_call(:get_specs, _, state) do
+    {:reply, state.specs, state}
+  end
+
+  ## Helpers
+
+  @spec parse_options!(list()) :: {Keyword.t(), Keyword.t()} | no_return()
+  defp parse_options!(options) do
+    gen_server_opts = Keyword.take(options, [:name])
+    measurement_specs = Keyword.get(options, :measurements, default_specs())
+    validate_measurement_specs!(measurement_specs)
+    period = Keyword.get(options, :period, @default_period)
+    validate_period!(period)
+    {[measurements: measurement_specs, period: period], gen_server_opts}
+  end
+
+  @spec validate_measurement_specs!(term()) :: :ok | no_return()
+  defp validate_measurement_specs!(measurement_specs) when is_list(measurement_specs) do
+    Enum.each(measurement_specs, &validate_measurement_spec!/1)
+    :ok
+  end
+
+  defp validate_measurement_specs!(other) do
+    raise ArgumentError, "Expected :measurements to be a list, got #{inspect(other)}"
+  end
+
+  @spec validate_measurement_spec!(term()) :: measurement_spec() | no_return()
+  defp validate_measurement_spec!({m, f, a})
+       when is_atom(m) and is_atom(f) and is_list(a) do
+    :ok
+  end
+
+  defp validate_measurement_spec!({_, _, _} = invalid_spec) do
+    raise ArgumentError, "Expected MFA measurement spec, got #{inspect(invalid_spec)}"
+  end
+
+  defp validate_measurement_spec!({event, {m, f, a}})
+       when is_list(event) and is_atom(m) and is_atom(f) and is_list(a) do
+    :ok
+  end
+
+  defp validate_measurement_spec!({_, {_, _, _}} = invalid_spec) do
+    raise ArgumentError,
+          "Expected event name with MFA measurement spec, got #{inspect(invalid_spec)}"
+  end
+
+  defp validate_measurement_spec!(vm_fun) when is_atom(vm_fun) do
+    case Code.ensure_loaded(Telemetry.Sampler.VM) do
+      {:module, _} ->
+        if function_exported?(Telemetry.Sampler.VM, vm_fun, 0) do
+          :ok
+        else
+          raise ArgumentError,
+                "Expected atom measurement spec to represent a function from " <>
+                  " #{inspect(Telemetry.Sampler.VM)} module, got #{inspect(vm_fun)}"
+        end
+
+      {:error, reason} ->
+        raise "Module #{inspect(Telemetry.Sampler.VM)} could not be loaded: #{inspect(reason)}"
+    end
+  end
+
+  @spec validate_period!(term()) :: :ok | no_return()
+  defp validate_period!(period) when is_integer(period) and period > 0, do: :ok
+
+  defp validate_period!(other),
+    do: raise(ArgumentError, "Expected :period to be a postivie integer, got #{inspect(other)}")
+
+  @spec schedule_collection(collect_in_millis :: non_neg_integer()) :: :ok
+  defp schedule_collection(collect_in_millis) do
+    Process.send_after(self(), :collect, collect_in_millis)
+  end
+
+  @spec collect_measurements([measurement_spec()]) :: [
+          {measurement_spec(),
+           {:ok, term()} | {:error, Exception.kind(), reason :: term(), Exception.stacktrace()}}
+        ]
+  defp collect_measurements(specs) do
+    Enum.map(specs, fn spec ->
+      value = collect_measurement(spec)
+      {spec, value}
+    end)
+  end
+
+  @spec collect_measurement(measurement_spec()) ::
+          {:ok, term()} | {:error, Exception.kind(), reason :: term(), Exception.stacktrace()}
+  defp collect_measurement(vm_fun) when is_atom(vm_fun) do
+    collect_measurement({Telemetry.Sampler.VM, vm_fun, []})
+  end
+
+  defp collect_measurement({_event, {_m, _f, _a} = mfa}) do
+    collect_measurement(mfa)
+  end
+
+  defp collect_measurement({m, f, a}) do
+    try do
+      {:ok, apply(m, f, a)}
+    catch
+      kind, reason ->
+        {:error, kind, reason, System.stacktrace()}
+    end
+  end
+
+  @spec dispatch_events_and_filter_misbehaving([
+          {measurement_spec(),
+           {:ok, term()} | {:error, Exception.kind(), reason :: term(), Exception.stacktrace()}}
+        ]) :: [measurement_spec()]
+  defp dispatch_events_and_filter_misbehaving(specs_with_values) do
+    specs_with_values
+    |> Enum.map(fn {spec, value} -> {spec, maybe_dispatch_events({spec, value})} end)
+    |> Enum.filter(fn {_spec, ok_or_error} -> ok_or_error == :ok end)
+    |> Enum.map(&elem(&1, 0))
+  end
+
+  @spec maybe_dispatch_events(
+          {measurement_spec(),
+           {:ok, term()} | {:error, Exception.kind(), reason :: term(), Exception.stacktrace()}}
+        ) :: :ok | :error
+  defp maybe_dispatch_events({spec, {:error, kind, reason, stack}}) do
+    formatted_error = Exception.format(kind, reason, stack)
+
+    Logger.error("""
+    Failed to collect measurement defined by spec #{inspect(spec)}:
+    #{formatted_error}
+    """)
+
+    :error
+  end
+
+  defp maybe_dispatch_events({vm_fun, {:ok, sample_or_samples}}) when is_atom(vm_fun) do
+    case maybe_dispatch_samples(sample_or_samples) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to dispatch values returned by invoking spec #{inspect(vm_fun)}: #{reason}"
+        )
+
+        :error
+    end
+  end
+
+  defp maybe_dispatch_events({{_m, _f, _a} = spec, {:ok, sample_or_samples}}) do
+    case maybe_dispatch_samples(sample_or_samples) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to dispatch values returned by invoking spec #{inspect(spec)}: #{reason}"
+        )
+
+        :error
+    end
+  end
+
+  defp maybe_dispatch_events({{event, {_m, _f, _a}}, {:ok, value}}) when is_number(value) do
+    sample = sample(event, value, %{})
+    :ok = maybe_dispatch_samples(sample)
+  end
+
+  defp maybe_dispatch_events({{_event, {_, _f, _a}} = spec, {:ok, other}}) do
+    Logger.error(
+      "Failed to dispatch the value returned by invoking spec #{inspect(spec)}: " <>
+        "expected a number, got #{inspect(other)}"
+    )
+
+    :error
+  end
+
+  @spec maybe_dispatch_samples(term()) :: :ok | {:error, String.t()}
+  defp maybe_dispatch_samples(maybe_samples) when is_list(maybe_samples) do
+    if Enum.all?(maybe_samples, &valid_sample?/1) do
+      for {:sample, event, value, metadata} <- maybe_samples do
+        Telemetry.execute(event, value, metadata)
+      end
+
+      :ok
+    else
+      {:error, "expected a list of samples, got #{inspect(maybe_samples)}"}
+    end
+  end
+
+  defp maybe_dispatch_samples(maybe_sample) do
+    if valid_sample?(maybe_sample) do
+      {:sample, event, value, metadata} = maybe_sample
+      Telemetry.execute(event, value, metadata)
+      :ok
+    else
+      {:error, "expected a sample, got #{inspect(maybe_sample)}"}
+    end
+  end
+
+  @spec valid_sample?(term()) :: boolean()
+  defp valid_sample?({:sample, event, value, metadata})
+       when is_list(event) and is_number(value) and is_map(metadata) do
+    true
+  end
+
+  defp valid_sample?(_) do
+    false
+  end
 end

--- a/lib/telemetry_sampler.ex
+++ b/lib/telemetry_sampler.ex
@@ -8,7 +8,9 @@ defmodule Telemetry.Sampler do
   2. As a tuple, where the first element is event name and the second element is an MFA returning a
      **number**. In this case, Sampler will dispatch an event with given name and value returned
      by the MFA invokation; event metadata will be always empty.
-  If the invokation of MFA returns an invalid value (i.e. it should return a number but doesn't), the measurement is removed from the list and the error is logged.
+
+  If the invokation of MFA returns an invalid value (i.e. it should return a number but doesn't),
+  the measurement is removed from the list and the error is logged.
 
   See the "Example - (...)" sections for more concrete examples.
 
@@ -98,7 +100,6 @@ defmodule Telemetry.Sampler do
       ...> end
       iex> :ok
       :ok
-
 
   Here we start 1000 processes placing a work order, waiting 500 milliseconds after starting each
   one. Given that the worker does its work in 1000 milliseconds, it means that new work orders come

--- a/lib/telemetry_sampler.ex
+++ b/lib/telemetry_sampler.ex
@@ -264,6 +264,7 @@ defmodule Telemetry.Sampler do
   @spec schedule_collection(collect_in_millis :: non_neg_integer()) :: :ok
   defp schedule_collection(collect_in_millis) do
     Process.send_after(self(), :collect, collect_in_millis)
+    :ok
   end
 
   @spec collect_measurements([measurement_spec()]) :: [

--- a/lib/telemetry_sampler.ex
+++ b/lib/telemetry_sampler.ex
@@ -65,8 +65,8 @@ defmodule Telemetry.Sampler do
   @doc """
   Returns a child specifiction for Sampler.
 
-  It accepts `nil` or `t:options/0` as an argument, meaning that it's valid to start it under the
-  supervisor as follows:
+  It accepts `t:options/0` as an argument, meaning that it's valid to start it under the supervisor
+  as follows:
 
       alias Telemetry.Sampler
       # use default options
@@ -79,10 +79,6 @@ defmodule Telemetry.Sampler do
   # Uncomment when dropping support for 1.4.x releases.
   # @spec child_spec(term()) :: Supervisor.child_spec()
   def child_spec(term)
-
-  def child_spec(nil) do
-    child_spec([])
-  end
 
   def child_spec(options) do
     %{

--- a/lib/telemetry_sampler.ex
+++ b/lib/telemetry_sampler.ex
@@ -95,7 +95,7 @@ defmodule Telemetry.Sampler do
       iex> Telemetry.attach(:handler, [:example_app, :message_queue_length], Handler, :handle)
       :ok
 
-  Now start let's assigning work to the worker:
+  Now let's start assigning work to the worker:
 
       iex> for _ <- 1..1000 do
       ...>   spawn_link(fn -> Worker.do_work(name) end)

--- a/lib/telemetry_sampler/vm.ex
+++ b/lib/telemetry_sampler/vm.ex
@@ -1,6 +1,6 @@
 defmodule Telemetry.Sampler.VM do
   @moduledoc """
-  Collection of functions returning samples of Erlang virtual machine metrics.
+  Collection of functions dispatching `Telemetry` events with Erlang VM metrics.
 
   See documentation for `Telemetry.Sampler` to learn how to use these functions.
   """
@@ -8,11 +8,12 @@ defmodule Telemetry.Sampler.VM do
   alias Telemetry.Sampler
 
   @doc """
-  Returns a list of samples with amount of memory dynamically allocated by the VM
+  Dispatches events with amount of memory dynamically allocated by the VM.
 
-  Each sample has the same event name, `[:vm, :memory]`. Event metadata includes only a single key,
-  `:type`, which corresponds to the type of memory measured. Sample value is the amount of memory of
-  type given in metadata allocated by the VM, in bytes.
+  A single event is dispatched for each type of memory measured. Event name is always
+  `[:vm, :memory]`. Event metadata includes only a single key, `:type`, which corresponds to the
+  type of memory measured. Event value is the amount of memory of type given in metadata allocated
+  by the VM, in bytes.
 
   The set of memory types may vary: see documentation for `:erlang.memory/0` to learn about possible
   values.

--- a/lib/telemetry_sampler/vm.ex
+++ b/lib/telemetry_sampler/vm.ex
@@ -1,11 +1,48 @@
 defmodule Telemetry.Sampler.VM do
   @moduledoc false
 
-  @spec memory() :: :ok
-  def memory() do
-    :erlang.memory()
-    |> Enum.each(fn {type, size} ->
-      Telemetry.execute([:vm, :memory], size, %{type: type})
-    end)
+  @spec total_memory() :: :ok
+  def total_memory() do
+    Telemetry.execute([:vm, :memory, :total], :erlang.memory(:total))
+  end
+
+  @spec processes_memory() :: :ok
+  def processes_memory() do
+    Telemetry.execute([:vm, :memory, :processes], :erlang.memory(:processes))
+  end
+
+  @spec processes_used_memory() :: :ok
+  def processes_used_memory() do
+    Telemetry.execute([:vm, :memory, :processes_used], :erlang.memory(:processes_used))
+  end
+
+  @spec system_memory() :: :ok
+  def system_memory() do
+    Telemetry.execute([:vm, :memory, :system], :erlang.memory(:system))
+  end
+
+  @spec atom_memory() :: :ok
+  def atom_memory() do
+    Telemetry.execute([:vm, :memory, :atom], :erlang.memory(:atom))
+  end
+
+  @spec atom_used_memory() :: :ok
+  def atom_used_memory() do
+    Telemetry.execute([:vm, :memory, :atom_used], :erlang.memory(:atom_used))
+  end
+
+  @spec binary_memory() :: :ok
+  def binary_memory() do
+    Telemetry.execute([:vm, :memory, :binary], :erlang.memory(:binary))
+  end
+
+  @spec code_memory() :: :ok
+  def code_memory() do
+    Telemetry.execute([:vm, :memory, :code], :erlang.memory(:code))
+  end
+
+  @spec ets_memory() :: :ok
+  def ets_memory() do
+    Telemetry.execute([:vm, :memory, :ets], :erlang.memory(:ets))
   end
 end

--- a/lib/telemetry_sampler/vm.ex
+++ b/lib/telemetry_sampler/vm.ex
@@ -21,7 +21,7 @@ defmodule Telemetry.Sampler.VM do
   def memory() do
     :erlang.memory()
     |> Enum.map(fn {type, size} ->
-      Sampler.sample([:vm, :memory], size, %{type: type})
+      Telemetry.execute([:vm, :memory], size, %{type: type})
     end)
   end
 end

--- a/lib/telemetry_sampler/vm.ex
+++ b/lib/telemetry_sampler/vm.ex
@@ -1,0 +1,27 @@
+defmodule Telemetry.Sampler.VM do
+  @moduledoc """
+  Collection of functions returning samples of Erlang virtual machine metrics.
+
+  See documentation for `Telemetry.Sampler` to learn how to use these functions.
+  """
+
+  alias Telemetry.Sampler
+
+  @doc """
+  Returns a list of samples with amount of memory dynamically allocated by the VM
+
+  Each sample has the same event name, `[:vm, :memory]`. Event metadata includes only a single key,
+  `:type`, which corresponds to the type of memory measured. Sample value is the amount of memory of
+  type given in metadata allocated by the VM, in bytes.
+
+  The set of memory types may vary: see documentation for `:erlang.memory/0` to learn about possible
+  values.
+  """
+  @spec memory() :: [Sampler.sample()]
+  def memory() do
+    :erlang.memory()
+    |> Enum.map(fn {type, size} ->
+      Sampler.sample([:vm, :memory], size, %{type: type})
+    end)
+  end
+end

--- a/lib/telemetry_sampler/vm.ex
+++ b/lib/telemetry_sampler/vm.ex
@@ -1,66 +1,11 @@
 defmodule Telemetry.Sampler.VM do
-  @moduledoc """
-  Collection of functions dispatching `Telemetry` events with Erlang VM metrics.
+  @moduledoc false
 
-  See documentation for `Telemetry.Sampler` to learn how to use these functions.
-  """
-
-  @doc """
-  Dispatches events with amount of memory dynamically allocated by the VM.
-
-  A single event is dispatched for each type of memory measured. Event name is always
-  `[:vm, :memory]`. Event metadata includes only a single key, `:type`, which corresponds to the
-  type of memory measured. Event value is the amount of memory of type given in metadata allocated
-  by the VM, in bytes.
-
-  The set of memory types may vary: see documentation for `:erlang.memory/0` to learn about possible
-  values.
-  """
   @spec memory() :: :ok
   def memory() do
     :erlang.memory()
     |> Enum.each(fn {type, size} ->
       Telemetry.execute([:vm, :memory], size, %{type: type})
     end)
-  end
-
-  @doc """
-  Dispatches an event with message queue length of the given process.
-
-  `process` can be a pid, atom, `{:global, term}` tuple or `{:via, module, term}` tuple. The event
-  is not dispatched if the `process`'s pid can't be resolved or the pid is not alive.
-
-  Event name is `[:vm, :message_queue_length]`. Event value is the measured message queue length.
-  Event metadata includes two keys: `:process`, which maps to `process` argument given to this
-  function, and `:pid`, which maps to the pid of the `process`.
-  """
-  @spec message_queue_length(pid() | atom() | {:global, term()} | {:via, module(), term()}) :: :ok
-  def message_queue_length(process) do
-    with {:ok, pid} <- resolve_pid(process),
-         {:message_queue_len, message_queue_length} <- Process.info(pid, :message_queue_len) do
-      metadata = %{process: process, pid: pid}
-      Telemetry.execute([:vm, :message_queue_length], message_queue_length, metadata)
-    else
-      _ ->
-        :ok
-    end
-  end
-
-  ## Helpers
-
-  @spec resolve_pid(pid() | atom() | {:global, term()} | {:via, module(), term()}) ::
-          {:ok, pid()} | :error
-  defp resolve_pid(process) when is_pid(process) do
-    {:ok, process}
-  end
-
-  defp resolve_pid(process) do
-    case GenServer.whereis(process) do
-      pid when is_pid(pid) ->
-        {:ok, pid}
-
-      _ ->
-        :error
-    end
   end
 end

--- a/lib/telemetry_sampler/vm.ex
+++ b/lib/telemetry_sampler/vm.ex
@@ -5,8 +5,6 @@ defmodule Telemetry.Sampler.VM do
   See documentation for `Telemetry.Sampler` to learn how to use these functions.
   """
 
-  alias Telemetry.Sampler
-
   @doc """
   Dispatches events with amount of memory dynamically allocated by the VM.
 
@@ -18,11 +16,51 @@ defmodule Telemetry.Sampler.VM do
   The set of memory types may vary: see documentation for `:erlang.memory/0` to learn about possible
   values.
   """
-  @spec memory() :: [Sampler.sample()]
+  @spec memory() :: :ok
   def memory() do
     :erlang.memory()
-    |> Enum.map(fn {type, size} ->
+    |> Enum.each(fn {type, size} ->
       Telemetry.execute([:vm, :memory], size, %{type: type})
     end)
+  end
+
+  @doc """
+  Dispatches an event with message queue length of the given process.
+
+  `process` can be a pid, atom, `{:global, term}` tuple or `{:via, module, term}` tuple. The event
+  is not dispatched if the `process`'s pid can't be resolved or the pid is not alive.
+
+  Event name is `[:vm, :message_queue_length]`. Event value is the measured message queue length.
+  Event metadata includes two keys: `:process`, which maps to `process` argument given to this
+  function, and `:pid`, which maps to the pid of the `process`.
+  """
+  @spec message_queue_length(pid() | atom() | {:global, term()} | {:via, module(), term()}) :: :ok
+  def message_queue_length(process) do
+    with {:ok, pid} <- resolve_pid(process),
+         {:message_queue_len, message_queue_length} <- Process.info(pid, :message_queue_len) do
+      metadata = %{process: process, pid: pid}
+      Telemetry.execute([:vm, :message_queue_length], message_queue_length, metadata)
+    else
+      _ ->
+        :ok
+    end
+  end
+
+  ## Helpers
+
+  @spec resolve_pid(pid() | atom() | {:global, term()} | {:via, module(), term()}) ::
+          {:ok, pid()} | :error
+  defp resolve_pid(process) when is_pid(process) do
+    {:ok, process}
+  end
+
+  defp resolve_pid(process) do
+    case GenServer.whereis(process) do
+      pid when is_pid(pid) ->
+        {:ok, pid}
+
+      _ ->
+        :error
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,9 @@ defmodule Telemetry.Sampler.MixProject do
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
-      preferred_cli_env: [docs: :docs],
-      deps: deps()
+      preferred_cli_env: preferred_cli_env(),
+      deps: deps(),
+      dialyzer: dialyzer()
     ]
   end
 
@@ -22,10 +23,22 @@ defmodule Telemetry.Sampler.MixProject do
   defp elixirc_paths(:test), do: ["lib/", "test/support/"]
   defp elixirc_paths(_), do: ["lib/"]
 
+  defp preferred_cli_env() do
+    [
+      docs: :docs,
+      dialyzer: :test
+    ]
+  end
+
   defp deps do
     [
       {:telemetry, "~> 0.1.0"},
-      {:ex_doc, "~> 0.19", only: :docs}
+      {:ex_doc, "~> 0.19", only: :docs},
+      {:dialyxir, "~> 1.0.0-rc.1", only: :test, runtime: false}
     ]
+  end
+
+  defp dialyzer() do
+    [ignore_warnings: ".dialyzer_ignore.exs"]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Telemetry.Sampler.MixProject do
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
+      preferred_cli_env: [docs: :docs],
       deps: deps()
     ]
   end
@@ -23,7 +24,8 @@ defmodule Telemetry.Sampler.MixProject do
 
   defp deps do
     [
-      {:telemetry, "~> 0.1.0"}
+      {:telemetry, "~> 0.1.0"},
+      {:ex_doc, "~> 0.19", only: :docs}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Telemetry.Sampler.MixProject do
       version: "0.1.0",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps()
     ]
   end
@@ -16,6 +17,9 @@ defmodule Telemetry.Sampler.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib/", "test/support/"]
+  defp elixirc_paths(_), do: ["lib/"]
 
   defp deps do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.3", "774306f84973fc3f1e2e8743eeaa5f5d29b117f3916e5de74c075c02f1b8ef55", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,8 @@
 %{
+  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.1.0", "e473e8dc0cc9310b33b8a5a11d7ca46d99b09a2a6338792bea961441ecb03cf9", [:mix], [], "hexpm"},
 }

--- a/test/support/test_handler.ex
+++ b/test/support/test_handler.ex
@@ -1,0 +1,8 @@
+defmodule Telemetry.Sampler.TestHandler do
+  @moduledoc false
+
+  def handle(event, value, metadata, config) do
+    message = {:event, event, value, metadata}
+    send(config.caller, message)
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,70 @@
+defmodule Telemetry.Sampler.TestHelpers do
+  alias Telemetry.Sampler.TestHandler
+
+  @doc """
+  Assert `Telemetry` event matching the given pattern has been dispatched.
+
+  THe caller first needs to attach an event handler to selected events using `attach_to/1`.
+  """
+  defmacro assert_dispatched(event_pattern, value_pattern, metadata_pattern, timeout \\ 1_000) do
+    quote do
+      assert_receive {:event, unquote(event_pattern), unquote(value_pattern),
+                      unquote(metadata_pattern)},
+                     unquote(timeout),
+                     """
+                     Event matching the pattern has not been dispatched.
+                     Make sure to attach a test event handler using `attach_to/1`.
+                     """
+    end
+  end
+
+  @doc """
+  Attaches an event handler sending a message to the caller whenever one of the selected events is
+  dispatched.
+
+  After attaching a handler you can assert the event has been dispatched using `assert_dispatched/4`.
+  """
+  def attach_to_many(events) when is_list(events) do
+    Telemetry.attach_many(make_ref(), events, TestHandler, :handle, %{caller: self()})
+  end
+
+  @doc """
+  Attaches an event handler sending a message to the caller whenever specified event is dispatched.
+
+  After attaching a handler you can assert the event has been dispatched using `assert_dispatched/4`.
+  """
+  def attach_to(event) do
+    Telemetry.attach(make_ref(), event, TestHandler, :handle, %{caller: self()})
+  end
+
+  @doc """
+  Invokes given function until it returns a truthy value.
+
+  Function is invoked `retries` times at maximum, sleeping `sleep` milliseconds between each
+  invokation.
+  """
+  def eventually(f, retries \\ 300, sleep \\ 100)
+  def eventually(_, 0, _), do: false
+
+  def eventually(f, retries, sleep) do
+    result =
+      try do
+        f.()
+      catch
+        kind, reason ->
+          ExUnit.Assertions.flunk("""
+          Error while waiting for function to return truthy value:
+          #{Exception.format(kind, reason, System.stacktrace())}
+          """)
+
+          false
+      end
+
+    unless result do
+      Process.sleep(sleep)
+      eventually(f, retries - 1, sleep)
+    else
+      result
+    end
+  end
+end

--- a/test/telemetry_sampler/vm_test.exs
+++ b/test/telemetry_sampler/vm_test.exs
@@ -1,0 +1,79 @@
+defmodule Telemetry.Sampler.VMTest do
+  use ExUnit.Case
+
+  import Telemetry.Sampler.TestHelpers
+
+  alias Telemetry.Sampler.VM
+
+  test "total_memory/0 dispatches [:vm, :memory, :total] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :total], _, ^empty_metadata, fn ->
+      VM.total_memory()
+    end
+  end
+
+  test "processes_memory/0 dispatches [:vm, :memory, :processes] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :processes], _, ^empty_metadata, fn ->
+      VM.processes_memory()
+    end
+  end
+
+  test "processes_used_memory/0 dispatches [:vm, :memory, :processes_used] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :processes_used], _, ^empty_metadata, fn ->
+      VM.processes_used_memory()
+    end
+  end
+
+  test "system_memory/0 dispatches [:vm, :memory, :system] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :system], _, ^empty_metadata, fn ->
+      VM.system_memory()
+    end
+  end
+
+  test "atom_memory/0 dispatches [:vm, :memory, :atom] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :atom], _, ^empty_metadata, fn ->
+      VM.atom_memory()
+    end
+  end
+
+  test "atom_used_memory/0 dispatches [:vm, :memory, :atom_used] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :atom_used], _, ^empty_metadata, fn ->
+      VM.atom_used_memory()
+    end
+  end
+
+  test "binary_memory/0 dispatches [:vm, :memory, :binary] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :binary], _, ^empty_metadata, fn ->
+      VM.binary_memory()
+    end
+  end
+
+  test "code_memory/0 dispatches [:vm, :memory, :code] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :code], _, ^empty_metadata, fn ->
+      VM.code_memory()
+    end
+  end
+
+  test "ets_memory/0 dispatches [:vm, :memory, :ets] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :memory, :ets], _, ^empty_metadata, fn ->
+      VM.ets_memory()
+    end
+  end
+end

--- a/test/telemetry_sampler_test.exs
+++ b/test/telemetry_sampler_test.exs
@@ -109,40 +109,17 @@ defmodule Telemetry.SamplerTest do
   end
 
   describe "vm_measurements/1" do
-    test "translates atom to measurement" do
+    test "translates :memory atom to measurement" do
       assert [{Sampler.VM, :memory, []}] == Sampler.vm_measurements([:memory])
     end
 
-    test "translates tuple to measurement" do
-      assert [
-               {Sampler.VM, :memory, []},
-               {Sampler.VM, :message_queue_length, [MyProcess]}
-             ] == Sampler.vm_measurements([{:memory, []}, {:message_queue_length, [MyProcess]}])
-    end
-
-    test "raises if function name is not an atom" do
+    test "raises when given unknown VM measurement" do
       assert_raise ArgumentError, fn ->
-        Sampler.vm_measurements(["memory"])
+        Sampler.vm_measurements([:cpu_usage])
       end
 
       assert_raise ArgumentError, fn ->
-        Sampler.vm_measurements([{"message_queue_length", [MyProcess]}])
-      end
-    end
-
-    test "raises if function arguments are not a list" do
-      assert_raise ArgumentError, fn ->
-        Sampler.vm_measurements([{:message_queue_length, MyProcess}])
-      end
-    end
-
-    test "raises if Telemetry.Sampler.VM doesn't export a function with given arity" do
-      assert_raise ArgumentError, fn ->
-        Sampler.vm_measurements([{:memory, [:total]}])
-      end
-
-      assert_raise ArgumentError, fn ->
-        Sampler.vm_measurements([{:message_queue_length, []}])
+        Sampler.vm_measurements([{:message_queue_length, [MyProcess]}])
       end
     end
 

--- a/test/telemetry_sampler_test.exs
+++ b/test/telemetry_sampler_test.exs
@@ -43,14 +43,14 @@ defmodule Telemetry.SamplerTest do
   @tag :capture_log
   test "sampler doesn't start given invalid measurement spec" do
     assert_raise ArgumentError, fn ->
-      Sampler.start(measurements: [:made_up_spec])
+      Sampler.start_link(measurements: [:made_up_spec])
     end
   end
 
   @tag :capture_log
   test "sampler doesn't start given invalid period" do
     assert_raise ArgumentError, fn ->
-      Sampler.start(period: "not a period")
+      Sampler.start_link(period: "not a period")
     end
   end
 
@@ -125,14 +125,6 @@ defmodule Telemetry.SamplerTest do
     {:ok, sampler} = Sampler.start_link(measurements: [invalid_spec])
 
     assert eventually(fn -> [] == Sampler.list_specs(sampler) end)
-  end
-
-  test "sampler can be started without linking" do
-    {:ok, pid} = Sampler.start()
-
-    assert {:links, []} == Process.info(self(), :links)
-
-    Sampler.stop(pid)
   end
 
   test "sampler can be started under supervisor using the old-style child spec" do

--- a/test/telemetry_sampler_test.exs
+++ b/test/telemetry_sampler_test.exs
@@ -1,3 +1,176 @@
 defmodule Telemetry.SamplerTest do
   use ExUnit.Case
+
+  import Telemetry.Sampler.TestHelpers
+
+  alias Telemetry.Sampler
+
+  defmodule TestMeasure do
+    def single_value(value), do: value
+
+    def single_sample(event, value, metadata),
+      do: Telemetry.Sampler.sample(event, value, metadata)
+
+    def multi_samples(events, value, metadata),
+      do: Enum.map(events, &Telemetry.Sampler.sample(&1, value, metadata))
+  end
+
+  test "sampler can be given a name" do
+    name = MySampler
+
+    {:ok, pid} = Sampler.start_link(name: name)
+
+    assert pid == Process.whereis(name)
+  end
+
+  test "sampler can have a sampling period configured" do
+    event = [:a, :test, :event]
+    value = 1
+    spec = {event, {TestMeasure, :single_value, [value]}}
+    period = 500
+
+    attach_to(event)
+    {:ok, _} = Sampler.start_link(measurements: [spec], period: period)
+
+    ## We don't apply active wait here because we want to make sure that two events are dispatched
+    ## *after* the period has passed, and not that at least two events are dispatched before one
+    ## period passes.
+    Process.sleep(period)
+    assert_dispatched ^event, ^value, _
+    assert_dispatched ^event, ^value, _
+  end
+
+  test "sampler doesn't start if the given sampling period is not an integer" do
+    assert_raise ArgumentError, fn ->
+      Sampler.start(period: "not an integer")
+    end
+  end
+
+  test "sampler can be given an atom corresponding to function from Telemetry.Sampler.VM module " <>
+         "as measurement spec" do
+    options = [measurements: [:memory]]
+    event = [:vm, :memory]
+
+    attach_to(event)
+    {:ok, _} = Sampler.start_link(options)
+
+    assert_dispatched ^event, _, _
+  end
+
+  test "sampler can't be given an atom which doesn't correspond to function from Telemetry.Sampler.VM module" do
+    assert_raise ArgumentError, fn ->
+      Sampler.start(measurements: [:made_up_function])
+    end
+  end
+
+  test "sampler can be given an MFA returning a single sample as measurement spec" do
+    event = [:a, :test, :event]
+    value = 1
+    metadata = %{some: "metadata"}
+    spec = {TestMeasure, :single_sample, [event, value, metadata]}
+
+    attach_to(event)
+    {:ok, _} = Sampler.start_link(measurements: [spec])
+
+    assert_dispatched ^event, ^value, ^metadata
+  end
+
+  test "sampler can be given an MFA returning a list of samples as measurement spec" do
+    event1 = [:a, :first, :test, :event]
+    event2 = [:a, :second, :test, :event]
+    value = 1
+    metadata = %{some: "metadata"}
+    spec = {TestMeasure, :multi_samples, [[event1, event2], value, metadata]}
+
+    attach_to_many([event1, event2])
+    {:ok, _} = Sampler.start_link(measurements: [spec])
+
+    assert_dispatched ^event1, ^value, ^metadata
+    assert_dispatched ^event2, ^value, ^metadata
+  end
+
+  test "sampler can be given an event name and an MFA returning a number as measurement spec" do
+    event = [:a, :test, :event]
+    value = 1
+    empty_metadata = %{}
+    spec = {event, {TestMeasure, :single_value, [value]}}
+
+    attach_to(event)
+    {:ok, _} = Sampler.start_link(measurements: [spec])
+
+    assert_dispatched ^event, ^value, ^empty_metadata
+  end
+
+  test "sampler's measurement specs can be listed" do
+    spec1 = :memory
+    spec2 = {[:a, :first, :test, :event], {TestMeasure, :single_value, [1]}}
+    spec3 = {TestMeasure, :single_sample, [[:a, :second, :test, :event], 1, %{}]}
+
+    {:ok, sampler} = Sampler.start_link(measurements: [spec1, spec2, spec3])
+    specs = Sampler.list_specs(sampler)
+
+    assert spec1 in specs
+    assert spec2 in specs
+    assert spec3 in specs
+    assert 3 == length(specs)
+  end
+
+  @tag :capture_log
+  test "measurement spec is removed from sampler if it returns incorrect value" do
+    invalid_specs = [
+      {TestMeasure, :not_a_sample, []},
+      {[:a, :test, :event], {TestMeasure, :not_a_number, []}}
+    ]
+
+    {:ok, sampler} = Sampler.start_link(measurements: invalid_specs)
+
+    assert eventually(fn -> [] == Sampler.list_specs(sampler) end)
+  end
+
+  @tag :capture_log
+  test "measurement spec is removed from sampler if it raises" do
+    invalid_spec = {TestMeasure, :raise, []}
+
+    {:ok, sampler} = Sampler.start_link(measurements: [invalid_spec])
+
+    assert eventually(fn -> [] == Sampler.list_specs(sampler) end)
+  end
+
+  test "sampler starts with default set of measurement specs" do
+    {:ok, sampler} = Sampler.start_link()
+
+    ## TODO: assert on default measurements
+    assert Sampler.default_specs() == Sampler.list_specs(sampler)
+  end
+
+  test "sampler can be started without linking" do
+    {:ok, pid} = Sampler.start()
+
+    assert {:links, []} == Process.info(self(), :links)
+
+    Sampler.stop(pid)
+  end
+
+  test "sampler can be started under supervisor using the old-style child spec" do
+    specs = [:memory]
+    child_id = MySampler
+    children = [Supervisor.Spec.worker(Sampler, [[measurements: specs]], id: child_id)]
+
+    {:ok, sup} = Supervisor.start_link(children, strategy: :one_for_one)
+
+    assert [{^child_id, sampler, :worker, [Sampler]}] = Supervisor.which_children(sup)
+    assert specs == Sampler.list_specs(sampler)
+  end
+
+  @tag :elixir_1_5_child_specs
+  test "sampler can be started under supervisor using the new-style child spec" do
+    specs = [:memory]
+    child_id = MySampler
+    children = [Supervisor.child_spec({Sampler, measurements: specs}, id: child_id)]
+
+    {:ok, sup} = Supervisor.start_link(children, strategy: :one_for_one)
+
+    assert [{^child_id, sampler, :worker, [Sampler]}] = Supervisor.which_children(sup)
+    assert specs == Sampler.list_specs(sampler)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,10 @@
-ExUnit.start()
+elixir_vsn = System.version()
+
+config =
+  if Version.match?(elixir_vsn, "~> 1.5") do
+    []
+  else
+    [exclude: :elixir_1_5_child_specs]
+  end
+
+ExUnit.start(config)


### PR DESCRIPTION
This PR adds a basic sampler API.

I've chosen a single-process design. If we find out that once process can't keep up with collecting all measurements, we can move to something else. Also, nobody is stopping anybody from starting multiple sampler processes.

I've also written a bit of documentation, so I won't dig into how measurements are defined here.

In the next step I'll focus on adding VM metrics, currently only the memory metric is defined.

/cc @chrismccord @josevalim @studzien