### PR TITLE
Configure TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: elixir
+matrix:
+  include:
+    - elixir: 1.4
+      otp_release: 18.3
+    - elixir: 1.4
+      otp_release: 19.3
+    - elixir: 1.4
+      otp_release: 20.3
+    - elixir: 1.5
+      otp_release: 18.3
+    - elixir: 1.5
+      otp_release: 19.3
+    - elixir: 1.5
+      otp_release: 20.3
+    - elixir: 1.6
+      otp_release: 19.3
+    - elixir: 1.6
+      otp_release: 20.3
+    - elixir: 1.6
+      otp_release: 21.0
+    - elixir: 1.7
+      otp_release: 19.3
+    - elixir: 1.7
+      otp_release: 20.3
+    - elixir: 1.7
+      otp_release: 21.0
+sudo: false
+before_script:
+  - mix deps.get
+script:
+  - mix test


### PR DESCRIPTION
This just adds a `.travis.yml` file, the same as in Telemetry to ensure that Sampler supports the same set of versions.

/cc @josevalim 