### PR TITLE
Start default Poller with the application

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,6 +4,7 @@
   locals_without_parens: [
     assert_dispatched: 3,
     assert_dispatched: 4,
-    assert_dispatch: 4
+    assert_dispatch: 4,
+    on_exit: 1
   ]
 ]

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ defmodule ExampleApp.Measurements do
 end
 
 Telemetry.Poller.start_link(
+  # include custom measurement
   measurements: [
-    # include custom measurement
     {ExampleApp.Measurements, :dispatch_session_count, []}
-    # include default VM measurements
-    | Telemetry.Poller.vm_measurements()
   ],
+  # include default VM measurements
+  vm_measurements: :default,
   period: 10_000 # configure sampling period
 )
 ```

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -25,12 +25,53 @@ defmodule Telemetry.Poller do
   You can start as many Pollers as you wish, but generally you shouldn't need to do it, unless
   you know that it's not keeping up with collecting all specified measurements.
 
-  Measurements need to be provided via `:measurements` option.
+  MFA measurements need to be provided via `:measurements` option.
 
   ## VM measurements
 
-  The `vm_measurements/1` function returns common measurements related to Erlang virtual machine
-  metrics. See its documentation for more information.
+  Besides regular MFA measurements, Poller also accepts a list of atoms describing measurements
+  related to Erlang virtual machine. VM measurements need to be provided via `:vm_measurements`
+  option. Below you can find a list of available measurements.
+
+  ### Available measurements
+
+  #### Memory
+
+  See documentation for `:erlang.memory/0` function for more information about each type of memory
+  measured.
+
+  * `:total_memory` - dispatches an event with total amount of currently allocated memory, in bytes.
+  Event name is `[:vm, :memory, :total]` and event metadata is empty;
+  * `:processes_memory` - dispatches an event with amount of memory cyrrently allocated for
+    processes, in bytes. Event name is `[:vm, :memory, :processes]` and event metadata is empty;
+  * `:processes_used_memory` - dispatches an event with amount of memory currently used for
+    processes, in bytes. Event name is `[:vm, :memory, :processes_used]` and event metadata is empty.
+    Memory measured is a fraction of value collected by `:processes_memory` measurement;
+  * `:binary_memory` - dispatches an event with amount of memory currently allocated for binaries.
+    Event name is `[:vm, :memory, :binary]` and event metadata is empty;
+  * `:ets_memory` - dispatches an event with amount of memory currently allocated for ETS tables.
+    Event name is `[:vm, :memory, :ets]` and event metadata is empty;
+  * `:system_memory` - dispatches an event with amount of currently allocated memory not directly
+    related to any process running in the VM, in bytes. Event name is `[:vm, :memory, :system]` and
+    event metadata is empty;
+  * `:atom_memory` - dispatches an event with amount of memory currently allocated for atoms. Event
+    name is `[:vm, :memory, :atom]` and event metadata is empty;
+  * `:atom_used_memory` - dispatches an event with amount of memory currently used for atoms. Event
+    name is `[:vm, :memory, :atom_used]` and event metadata is empty;
+  * `:code_memory` - dispatches an event with amount of memory currently allocated for code. Event
+    name is `[:vm, :memory, :code]` and event metadata is empty;
+
+  ### Default measurements
+
+  By default Poller uses `:total_memory`, `:processes_memory`, `:processes_used_memory`,
+  `:binary_memory` and `:ets_memory` VM measurements.
+
+  ### Example
+
+      alias Telemetry.Poller
+      Poller.start_link(
+        vm_measurements: [:total_memory, :processes_memory, :atom_memory]
+      )
 
   ## Example - measuring message queue length of the process
 
@@ -209,6 +250,7 @@ defmodule Telemetry.Poller do
           {:name, GenServer.name()}
           | {:period, period()}
           | {:measurements, [measurement()]}
+          | {:vm_measurements, :default | [vm_measurement()]}
   @type period :: pos_integer()
   @type measurement() :: mfa()
   @type vm_measurement() ::
@@ -254,10 +296,13 @@ defmodule Telemetry.Poller do
 
   Useful for starting Pollers as a part of a supervision tree.
 
-  ### Options
+  ## Options
 
   * `:measurements` - a list of measurements used by Poller. For description of possible values
     see `Telemetry.Poller` module documentation;
+  * `:vm_measurements` - a list of atoms describing measurements related to the Erlang VM, or an
+    atom `:default` in which case default VM measurements are used. See "VM measurements" section in
+    the module documentation for more information. Default value is `:default`;
   * `:period` - time period before performing the same measurement again, in milliseconds. Default
     value is #{@default_period} ms;
   * `:name` - the name of the Poller process. See "Name Registragion" section of `GenServer`
@@ -285,65 +330,6 @@ defmodule Telemetry.Poller do
   @spec list_measurements(t()) :: [measurement()]
   def list_measurements(poller) do
     GenServer.call(poller, :get_measurements)
-  end
-
-  @doc """
-  Returns measurements dispatching events with Erlang virtual machine metrics
-
-  It accepts a list `t:vm_measurement/0`s and returns a list of `t:measurement/0`s which can
-  be provided to `start_link/1`'s `:measurements` option.
-
-  Do not rely on the exact values returned by this function - the only guarantee is that they
-  are of type `t:measurement/0` and their modification will not be considered a breaking change,
-  unless the shape of events dispatched by returned measurements changes.
-
-  Returned measurements are unique.
-
-  ## Available measurements
-
-  ### Memory
-
-  See documentation for `:erlang.memory/0` function for more information about each type of memory
-  measured.
-
-  * `:total_memory` - dispatches an event with total amount of currently allocated memory, in bytes.
-  Event name is `[:vm, :memory, :total]` and event metadata is empty;
-  * `:processes_memory` - dispatches an event with amount of memory cyrrently allocated for
-    processes, in bytes. Event name is `[:vm, :memory, :processes]` and event metadata is empty;
-  * `:processes_used_memory` - dispatches an event with amount of memory currently used for
-    processes, in bytes. Event name is `[:vm, :memory, :processes_used]` and event metadata is empty.
-    Memory measured is a fraction of value collected by `:processes_memory` measurement;
-  * `:binary_memory` - dispatches an event with amount of memory currently allocated for binaries.
-    Event name is `[:vm, :memory, :binary]` and event metadata is empty;
-  * `:ets_memory` - dispatches an event with amount of memory currently allocated for ETS tables.
-    Event name is `[:vm, :memory, :ets]` and event metadata is empty;
-  * `:system_memory` - dispatches an event with amount of currently allocated memory not directly
-    related to any process running in the VM, in bytes. Event name is `[:vm, :memory, :system]` and
-    event metadata is empty;
-  * `:atom_memory` - dispatches an event with amount of memory currently allocated for atoms. Event
-    name is `[:vm, :memory, :atom]` and event metadata is empty;
-  * `:atom_used_memory` - dispatches an event with amount of memory currently used for atoms. Event
-    name is `[:vm, :memory, :atom_used]` and event metadata is empty;
-  * `:code_memory` - dispatches an event with amount of memory currently allocated for code. Event
-    name is `[:vm, :memory, :code]` and event metadata is empty;
-
-  ## Default measurements
-
-  The 0-arity version of this function includes `:total_memory`, `:processes_memory`,
-  `:processes_used_memory`, `:binary_memory` and `:ets_memory` measurements by default.
-
-  ## Examples
-
-      alias Telemetry.Poller
-      Poller.start_link(
-        measurements: Poller.vm_measurements() ++ Poller.vm_measurements(:atom_memory)
-      )
-  """
-  @spec vm_measurements([vm_measurement()]) :: [measurement()]
-  def vm_measurements(vm_measurements \\ @default_vm_measurements)
-      when is_list(vm_measurements) do
-    measurements = parse_vm_measurements!(vm_measurements)
-    Enum.uniq(measurements)
   end
 
   ## GenServer callbacks
@@ -379,9 +365,16 @@ defmodule Telemetry.Poller do
     gen_server_opts = Keyword.take(options, [:name])
     measurements = Keyword.get(options, :measurements, [])
     validate_measurements!(measurements)
+
+    vm_measurements =
+      options
+      |> Keyword.get(:vm_measurements, :default)
+      |> parse_vm_measurements!()
+      |> Enum.uniq()
+
     period = Keyword.get(options, :period, @default_period)
     validate_period!(period)
-    {[measurements: measurements, period: period], gen_server_opts}
+    {[measurements: measurements ++ vm_measurements, period: period], gen_server_opts}
   end
 
   @spec validate_measurements!(term()) :: :ok | no_return()
@@ -440,7 +433,11 @@ defmodule Telemetry.Poller do
       :error
   end
 
-  @spec parse_vm_measurements!([term()]) :: [measurement()] | no_return()
+  @spec parse_vm_measurements!(term()) :: [measurement()] | no_return()
+  defp parse_vm_measurements!(:default) do
+    parse_vm_measurements!(@default_vm_measurements)
+  end
+
   defp parse_vm_measurements!(vm_measurements) do
     Enum.map(vm_measurements, &parse_vm_measurement!/1)
   end
@@ -451,7 +448,7 @@ defmodule Telemetry.Poller do
   end
 
   defp parse_vm_measurement!(other) do
-    raise ArgumentError, "Expected VM measurement, got #{inspect(other)}"
+    raise ArgumentError, "unknown VM measurement #{inspect(other)}"
   end
 
   @spec vm_measurement(function :: atom()) :: measurement()

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -3,29 +3,10 @@ defmodule Telemetry.Poller do
   A time-based poller to periodically dispatch Telemetry events.
 
   Measurements are MFAs called periodically by the Poller process. These MFAs should collect
-  a value (if possible) and dispatch an event using `Telemetry.execute/3` function.
-
-  If the invokation of the MFA fails, the measurement is removed from the Poller.
+  a value (if possible) and dispatch an event using `Telemetry.execute/3` function. If the
+  invokation of the MFA fails, the measurement is removed from the Poller.
 
   See the "Example - (...)" sections for more concrete examples.
-
-  ## Starting and stopping
-
-  You can start the Poller using the `start_link/1` function. Poller can be alaso started as a
-  part of your supervision tree, using both the old-style and the new-style child specifications:
-
-      # pre Elixir 1.5.0
-      children = [Supervisor.Spec.worker(Telemetry.Poller, [[period: 5000]])]
-
-      # post Elixir 1.5.0
-      children = [{Telemetry.Poller, [period: 5000]}]
-
-      Supervisor.start_link(children, [strategy: :one_for_one])
-
-  You can start as many Pollers as you wish, but generally you shouldn't need to do it, unless
-  you know that it's not keeping up with collecting all specified measurements.
-
-  MFA measurements need to be provided via `:measurements` option.
 
   ## VM measurements
 
@@ -72,6 +53,33 @@ defmodule Telemetry.Poller do
       Poller.start_link(
         vm_measurements: [:total_memory, :processes_memory, :atom_memory]
       )
+
+  ## Starting and stopping
+
+  By default a single Poller is started under `Telemetry.Poller` application. It is started with
+  a default set of options and a name `Telemetry.Poller.Default`. You can configure the default
+  Poller using application environment:
+
+      config :telemetry_poller, :default,
+        measurements: [{ExampleApp.Measurements, :measurement, []}]
+
+  The default Poller can be disabled by setting `:default` key to `false`:
+
+      config :telemetry_poller, default: false
+
+  You can start your own Poller using the `start_link/1` function. Poller can be alaso started as a
+  part of your supervision tree, using both the old-style and the new-style child specifications:
+
+      # pre Elixir 1.5.0
+      children = [Supervisor.Spec.worker(Telemetry.Poller, [[period: 5000]])]
+
+      # post Elixir 1.5.0
+      children = [{Telemetry.Poller, [period: 5000]}]
+
+      Supervisor.start_link(children, [strategy: :one_for_one])
+
+  You can start as many Pollers as you wish, but generally you shouldn't need to do it, unless
+  you know that it's not keeping up with collecting all specified measurements.
 
   ## Example - measuring message queue length of the process
 

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -301,7 +301,7 @@ defmodule Telemetry.Poller do
   * `:measurements` - a list of measurements used by Poller. For description of possible values
     see `Telemetry.Poller` module documentation;
   * `:vm_measurements` - a list of atoms describing measurements related to the Erlang VM, or an
-    atom `:default` in which case default VM measurements are used. See "VM measurements" section in
+    atom `:default`, in which case default VM measurements are used. See "VM measurements" section in
     the module documentation for more information. Default value is `:default`;
   * `:period` - time period before performing the same measurement again, in milliseconds. Default
     value is #{@default_period} ms;
@@ -384,7 +384,7 @@ defmodule Telemetry.Poller do
   end
 
   defp validate_measurements!(other) do
-    raise ArgumentError, "Expected :measurements to be a list, got #{inspect(other)}"
+    raise ArgumentError, "expected :measurements to be a list, got #{inspect(other)}"
   end
 
   @spec validate_measurement!(term()) :: :ok | no_return()
@@ -395,14 +395,14 @@ defmodule Telemetry.Poller do
 
   defp validate_measurement!(invalid_measurement) do
     raise ArgumentError,
-          "Expected measurement, got #{inspect(invalid_measurement)}"
+          "expected measurement, got #{inspect(invalid_measurement)}"
   end
 
   @spec validate_period!(term()) :: :ok | no_return()
   defp validate_period!(period) when is_integer(period) and period > 0, do: :ok
 
   defp validate_period!(other),
-    do: raise(ArgumentError, "Expected :period to be a postivie integer, got #{inspect(other)}")
+    do: raise(ArgumentError, "expected :period to be a postivie integer, got #{inspect(other)}")
 
   @spec schedule_measurement(collect_in_millis :: non_neg_integer()) :: :ok
   defp schedule_measurement(collect_in_millis) do

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -44,8 +44,8 @@ defmodule Telemetry.Poller do
 
   ### Default measurements
 
-  By default Poller uses `:total_memory`, `:processes_memory`, `:processes_used_memory`,
-  `:binary_memory` and `:ets_memory` VM measurements.
+  When `:default` is provided as the value of `:vm_measurement` options, Poller uses `:total_memory`,
+  `:processes_memory`, `:processes_used_memory`, `:binary_memory` and `:ets_memory` VM measurements.
 
   ### Example
 
@@ -57,11 +57,13 @@ defmodule Telemetry.Poller do
   ## Starting and stopping
 
   By default a single Poller is started under `Telemetry.Poller` application. It is started with
-  a default set of options and a name `Telemetry.Poller.Default`. You can configure the default
+  name `Telemetry.Poller.Default` and default set of VM measurements. You can configure the default
   Poller using application environment:
 
       config :telemetry_poller, :default,
         measurements: [{ExampleApp.Measurements, :measurement, []}]
+
+  Provided options will be merged with the defaults.
 
   The default Poller can be disabled by setting `:default` key to `false`:
 
@@ -310,7 +312,7 @@ defmodule Telemetry.Poller do
     see `Telemetry.Poller` module documentation;
   * `:vm_measurements` - a list of atoms describing measurements related to the Erlang VM, or an
     atom `:default`, in which case default VM measurements are used. See "VM measurements" section in
-    the module documentation for more information. Default value is `:default`;
+    the module documentation for more information. Default value is `[]`;
   * `:period` - time period before performing the same measurement again, in milliseconds. Default
     value is #{@default_period} ms;
   * `:name` - the name of the Poller process. See "Name Registragion" section of `GenServer`
@@ -376,7 +378,7 @@ defmodule Telemetry.Poller do
 
     vm_measurements =
       options
-      |> Keyword.get(:vm_measurements, :default)
+      |> Keyword.get(:vm_measurements, [])
       |> parse_vm_measurements!()
       |> Enum.uniq()
 

--- a/lib/telemetry_poller/application.ex
+++ b/lib/telemetry_poller/application.ex
@@ -1,0 +1,19 @@
+defmodule Telemetry.Poller.Application do
+  @moduledoc false
+
+  def start(_type, _args) do
+    import Supervisor.Spec, only: [worker: 2]
+
+    default_poller_opts =
+      Application.get_env(:telemetry_poller, :default, name: Telemetry.Poller.Default)
+
+    children =
+      if default_poller_opts do
+        [worker(Telemetry.Poller, [default_poller_opts])]
+      else
+        []
+      end
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: Telemetry.Poller.Supervisor)
+  end
+end

--- a/lib/telemetry_poller/application.ex
+++ b/lib/telemetry_poller/application.ex
@@ -4,12 +4,13 @@ defmodule Telemetry.Poller.Application do
   def start(_type, _args) do
     import Supervisor.Spec, only: [worker: 2]
 
-    default_poller_opts =
-      Application.get_env(:telemetry_poller, :default, name: Telemetry.Poller.Default)
+    poller_opts =
+      Application.get_env(:telemetry_poller, :default, [])
 
     children =
-      if default_poller_opts do
-        [worker(Telemetry.Poller, [default_poller_opts])]
+      if poller_opts do
+        poller_opts = Keyword.merge([name: Telemetry.Poller.Default], poller_opts)
+        [worker(Telemetry.Poller, [poller_opts])]
       else
         []
       end

--- a/lib/telemetry_poller/application.ex
+++ b/lib/telemetry_poller/application.ex
@@ -4,12 +4,13 @@ defmodule Telemetry.Poller.Application do
   def start(_type, _args) do
     import Supervisor.Spec, only: [worker: 2]
 
-    poller_opts =
-      Application.get_env(:telemetry_poller, :default, [])
+    poller_opts = Application.get_env(:telemetry_poller, :default, [])
 
     children =
       if poller_opts do
-        poller_opts = Keyword.merge([name: Telemetry.Poller.Default], poller_opts)
+        poller_opts =
+          Keyword.merge([name: Telemetry.Poller.Default, vm_measurements: :default], poller_opts)
+
         [worker(Telemetry.Poller, [poller_opts])]
       else
         []

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule Telemetry.Poller.MixProject do
 
   def application do
     [
+      mod: {Telemetry.Poller.Application, []},
       extra_applications: [:logger]
     ]
   end

--- a/test/telemetry_poller/application_test.exs
+++ b/test/telemetry_poller/application_test.exs
@@ -21,14 +21,15 @@ defmodule Telemetry.Poller.ApplicationTest do
     :ok
   end
 
-  test "default poller is started with preconfigured name" do
+  test "default poller is started with preconfigured name and VM measurements" do
     poller = Telemetry.Poller.Default
 
     Application.delete_env(:telemetry_poller, :default)
     Application.ensure_all_started(:telemetry_poller)
 
     assert eventually(fn -> not is_nil(Process.whereis(poller)) end)
-    assert Poller.list_measurements(Telemetry.Poller.Default)
+    measurements = Poller.list_measurements(Telemetry.Poller.Default)
+    assert Enum.all?(measurements, fn {mod, _, _} -> mod == Telemetry.Poller.VM end)
   end
 
   test "default poller can be configured using application environment" do

--- a/test/telemetry_poller/application_test.exs
+++ b/test/telemetry_poller/application_test.exs
@@ -1,0 +1,43 @@
+defmodule Telemetry.Poller.ApplicationTest do
+  use ExUnit.Case, async: false
+
+  alias Telemetry.Poller
+
+  setup do
+    Application.stop(:telemetry_poller)
+
+    on_exit fn ->
+      Application.ensure_all_started(:telemetry_poller)
+    end
+  end
+
+  test "default poller is started with preconfigured name" do
+    Application.ensure_all_started(:telemetry_poller)
+
+    assert Poller.list_measurements(Telemetry.Poller.Default)
+  end
+
+  test "default poller can be configured using application environment" do
+    name = MyPoller
+
+    Application.put_env(
+      :telemetry_poller,
+      :default,
+      name: name,
+      vm_measurements: [],
+      measurements: []
+    )
+
+    Application.ensure_all_started(:telemetry_poller)
+
+    assert [] == Poller.list_measurements(name)
+  end
+
+  test "default poller can be disabled using application environment" do
+    Application.put_env(:telemetry_poller, :default, false)
+
+    Application.ensure_all_started(:telemetry_poller)
+
+    refute Process.whereis(Telemetry.Poller.Default)
+  end
+end

--- a/test/telemetry_poller_test.exs
+++ b/test/telemetry_poller_test.exs
@@ -66,7 +66,9 @@ defmodule Telemetry.PollerTest do
     measurement1 = {Telemetry.Poller.VM, :memory, []}
     measurement2 = {TestMeasure, :single_sample, [[:a, :second, :test, :event], 1, %{}]}
 
-    {:ok, poller} = Poller.start_link(measurements: [measurement1, measurement2])
+    {:ok, poller} =
+      Poller.start_link(measurements: [measurement1, measurement2], vm_measurements: [])
+
     measurements = Poller.list_measurements(poller)
 
     assert measurement1 in measurements
@@ -78,63 +80,77 @@ defmodule Telemetry.PollerTest do
   test "measurement is removed from poller if it raises" do
     invalid_measurement = {TestMeasure, :raise, []}
 
-    {:ok, poller} = Poller.start_link(measurements: [invalid_measurement])
+    {:ok, poller} = Poller.start_link(measurements: [invalid_measurement], vm_measurements: [])
 
     assert eventually(fn -> [] == Poller.list_measurements(poller) end)
   end
 
   test "poller can be started under supervisor using the old-style child spec" do
-    measurements = [{Telemetry.Poller.VM, :memory, []}]
+    measurement = {Telemetry.Poller.VM, :memory, []}
     child_id = MyPoller
-    children = [Supervisor.Spec.worker(Poller, [[measurements: measurements]], id: child_id)]
+    children = [Supervisor.Spec.worker(Poller, [[measurements: [measurement]]], id: child_id)]
 
     {:ok, sup} = Supervisor.start_link(children, strategy: :one_for_one)
 
     assert [{^child_id, poller, :worker, [Poller]}] = Supervisor.which_children(sup)
-    assert measurements == Poller.list_measurements(poller)
+    assert measurement in Poller.list_measurements(poller)
   end
 
   @tag :elixir_1_5_child_specs
   test "poller can be started under supervisor using the new-style child spec" do
-    measurements = [{Telemetry.Poller.VM, :memory, []}]
+    measurement = {Telemetry.Poller.VM, :memory, []}
     child_id = MyPoller
-    children = [Supervisor.child_spec({Poller, measurements: measurements}, id: child_id)]
+    children = [Supervisor.child_spec({Poller, measurements: [measurement]}, id: child_id)]
 
     {:ok, sup} = Supervisor.start_link(children, strategy: :one_for_one)
 
     assert [{^child_id, poller, :worker, [Poller]}] = Supervisor.which_children(sup)
-    assert measurements == Poller.list_measurements(poller)
+    assert measurement in Poller.list_measurements(poller)
   end
 
-  describe "vm_measurements/1" do
-    for memory_type <- [
+  test "poller starts with a default set of VM measurements" do
+    {:ok, poller} = Poller.start_link()
+    measurements = Poller.list_measurements(poller)
+
+    for measurement_fun <- [
           :total_memory,
           :processes_memory,
           :processes_used_memory,
-          :system_memory,
-          :atom_memory,
-          :atom_used_memory,
-          :binary_memory,
-          :code_memory,
-          :ets_memory
+          :ets_memory,
+          :binary_memory
         ] do
-      test "translates #{inspect(memory_type)} atom to measurement" do
-        assert [{_, _, _}] = Poller.vm_measurements([unquote(memory_type)])
-      end
+      assert {Telemetry.Poller.VM, measurement_fun, []} in measurements
     end
+  end
 
-    test "raises when given unknown VM measurement" do
-      assert_raise ArgumentError, fn ->
-        Poller.vm_measurements([:cpu_usage])
-      end
+  test "poller can be given a list of VM measurements" do
+    vm_measurements = [
+      :total_memory,
+      :processes_memory,
+      :processes_used_memory,
+      :system_memory,
+      :atom_memory,
+      :atom_used_memory,
+      :binary_memory,
+      :code_memory,
+      :ets_memory
+    ]
 
-      assert_raise ArgumentError, fn ->
-        Poller.vm_measurements([{:message_queue_length, [MyProcess]}])
-      end
+    {:ok, poller} = Poller.start_link(vm_measurements: vm_measurements)
+
+    assert length(vm_measurements) == length(Poller.list_measurements(poller))
+  end
+
+  @tag :capture_log
+  test "poller doesn't start given invalid VM measurement" do
+    assert_raise ArgumentError, fn ->
+      Poller.start_link(vm_measurements: [:cpu_usage])
     end
+  end
 
-    test "returns unique measurements" do
-      assert [{_, _, _}] = Poller.vm_measurements([:total_memory, :total_memory])
-    end
+  test "poller registers unique VM measurements" do
+    {:ok, poller} = Poller.start_link(vm_measurements: [:total_memory, :total_memory])
+
+    assert 1 == length(Poller.list_measurements(poller))
   end
 end


### PR DESCRIPTION
This PR changes the application so that the default Poller is started under its supervision tree. This Poller can be configured or disabled via application env.

Additionally, I changed the process of attaching VM measurements. Now there is a separate option, `:vm_measurements`, which accepts the same values as (now removed) `vm_measurements/1` function. 

Closes #9 