### PR TITLE
Add run queue lengths VM measurements

### DIFF
--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -72,6 +72,9 @@ defmodule Telemetry.Poller do
       For dirty CPU run queue, the event name is `[:vm, :run_queues_length, :dirty_cpu]` and the
       event metadata is empty.
 
+      If you do not need the individual run queue lengths, it is more efficient to use
+      `:total_run_queue_lengths` measurement.
+
   ### Default measurements
 
   When `:default` is provided as the value of `:vm_measurement` options, Poller uses `:total_memory`,

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -42,7 +42,7 @@ defmodule Telemetry.Poller do
   * `:code_memory` - dispatches an event with amount of memory currently allocated for code. Event
     name is `[:vm, :memory, :code]` and event metadata is empty;
 
-  #### Run queues length
+  #### Run queue lengths
 
   A run queue is a queue of tasks which are going to be scheduled on a particular scheduler
   (although processes can be migrated between the run queues of the same type). A length of a run
@@ -61,6 +61,10 @@ defmodule Telemetry.Poller do
       Note that the method of making this measurement varies between different Erlang versions: for
       Erlang 18 and 19, the implementation is less efficient than for version 20 and up.
 
+      The length of all queues is not gathered atomically, so the event value does not represent
+      a consistent snapshot of the run queues' state. However, the value is accurate enough to help
+      to indentify issues in a running system.
+
   * `:run_queue_lengths` - dispatches events with individual normal run queue lengths and a dirty
     CPU run queue length (if dirty schedulers are available).
 
@@ -69,8 +73,12 @@ defmodule Telemetry.Poller do
       with the scheduler ID of the queue. Note that number of schedulers is fixed at virtual machine
       boot time, so the number of events emitted on each measurement is constant.
 
-      For dirty CPU run queue, the event name is `[:vm, :run_queues_length, :dirty_cpu]` and the
+      For dirty CPU run queue, the event name is `[:vm, :run_queue_lengths, :dirty_cpu]` and the
       event metadata is empty.
+
+      The length of all queues is not gathered atomically, so the event values do not represent
+      a consistent snapshot of the run queues' state. However, the value is accurate enough to help
+      to indentify issues in a running system.
 
       If you do not need the individual run queue lengths, it is more efficient to use
       `:total_run_queue_lengths` measurement.

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -44,44 +44,46 @@ defmodule Telemetry.Poller do
 
   #### Run queue lengths
 
-  A run queue is a queue of tasks which are going to be scheduled on a particular scheduler
-  (although processes can be migrated between the run queues of the same type). A length of a run
-  queue corresponds to the amount of work accumulated in the system. If a run queue length is
-  constantly growing, it means that the BEAM is not keeping up with executing all the tasks.
+  On startup, the Erlang VM starts many schedulers to do both IO and CPU work. If a process
+  needs to do some work or wait on IO, it is allocated to the appropriate scheduler. The run
+  queue is a queue of tasks to be scheduled. A length of a run queue corresponds to the amount
+  of work accumulated in the system. If a run queue length is constantly growing, it means that
+  the BEAM is not keeping up with executing all the tasks.
 
-  There are several run queue types in the Erlang Virtual Machine. Each normal scheduler has
-  its own run queue, and since Erlang 20.0 there is one dirty CPU run queue, and one dirty IO run queue.
+  There are several run queue types in the Erlang VMe. Each CPU scheduler (usually one per core)
+  has its own run queue, and since Erlang 20.0 there is one dirty CPU run queue, and one dirty
+  IO run queue.
 
   The following VM measurements related to run queue lengths are available:
 
   * `:total_run_queue_lengths` - dispatches an event with a sum of normal schedulers' run queue lengths
     and a dirty CPU run queue length (if dirty schedulers are available). Event name is
-    `[:vm, run_queue_lengths, :normal]` and event metadata is empty.
+    `[:vm, run_queue_lengths, :total]` and event metadata is empty.
 
-      Note that the method of making this measurement varies between different Erlang versions: for
-      Erlang 18 and 19, the implementation is less efficient than for version 20 and up.
+    Note that the method of making this measurement varies between different Erlang versions: for
+    Erlang 18 and 19, the implementation is less efficient than for version 20 and up.
 
-      The length of all queues is not gathered atomically, so the event value does not represent
-      a consistent snapshot of the run queues' state. However, the value is accurate enough to help
-      to indentify issues in a running system.
+    The length of all queues is not gathered atomically, so the event value does not represent
+    a consistent snapshot of the run queues' state. However, the value is accurate enough to help
+    to indentify issues in a running system.
 
   * `:run_queue_lengths` - dispatches events with individual normal run queue lengths and a dirty
     CPU run queue length (if dirty schedulers are available).
 
-      For normal run queues, event name
-      is `[:vm, run_queue_lengths, :normal]` and event metadata includes a single key, `:scheduler_id`,
-      with the scheduler ID of the queue. Note that number of schedulers is fixed at virtual machine
-      boot time, so the number of events emitted on each measurement is constant.
+    For normal run queues, event name is `[:vm, run_queue_lengths, :normal]` and event metadata
+    includes a single key, `:scheduler_id`, with the scheduler ID of the queue. Note that number
+    of schedulers is fixed at virtual machine boot time, so the number of events emitted on each
+    measurement is constant.
 
-      For dirty CPU run queue, the event name is `[:vm, :run_queue_lengths, :dirty_cpu]` and the
-      event metadata is empty.
+    For dirty CPU run queue, the event name is `[:vm, :run_queue_lengths, :dirty_cpu]` and the
+    event metadata is empty.
 
-      The length of all queues is not gathered atomically, so the event values do not represent
-      a consistent snapshot of the run queues' state. However, the value is accurate enough to help
-      to indentify issues in a running system.
+    The length of all queues is not gathered atomically, so the event values do not represent
+    a consistent snapshot of the run queues' state. However, the value is accurate enough to help
+    to indentify issues in a running system.
 
-      If you do not need the individual run queue lengths, it is more efficient to use
-      `:total_run_queue_lengths` measurement.
+    If you do not need the individual run queue lengths, it is more efficient to use
+    `:total_run_queue_lengths` measurement.
 
   ### Default measurements
 

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -88,7 +88,8 @@ defmodule Telemetry.Poller do
   ### Default measurements
 
   When `:default` is provided as the value of `:vm_measurement` options, Poller uses `:total_memory`,
-  `:processes_memory`, `:processes_used_memory`, `:binary_memory` and `:ets_memory` VM measurements.
+  `:processes_memory`, `:processes_used_memory`, `:binary_memory`, `:ets_memory`
+  and `:total_run_queue_lengths` VM measurements.
 
   ### Example
 

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -42,6 +42,36 @@ defmodule Telemetry.Poller do
   * `:code_memory` - dispatches an event with amount of memory currently allocated for code. Event
     name is `[:vm, :memory, :code]` and event metadata is empty;
 
+  #### Run queues length
+
+  A run queue is a queue of tasks which are going to be scheduled on a particular scheduler
+  (although processes can be migrated between the run queues of the same type). A length of a run
+  queue corresponds to the amount of work accumulated in the system. If a run queue length is
+  constantly growing, it means that the BEAM is not keeping up with executing all the tasks.
+
+  There are several run queue types in the Erlang Virtual Machine. Each normal scheduler has
+  its own run queue, and since Erlang 20.0 there is one dirty CPU run queue, and one dirty IO run queue.
+
+  The following VM measurements related to run queue lengths are available:
+
+  * `:total_run_queue_lengths` - dispatches an event with a sum of normal schedulers' run queue lengths
+    and a dirty CPU run queue length (if dirty schedulers are available). Event name is
+    `[:vm, run_queue_lengths, :normal]` and event metadata is empty.
+
+      Note that the method of making this measurement varies between different Erlang versions: for
+      Erlang 18 and 19, the implementation is less efficient than for version 20 and up.
+
+  * `:run_queue_lengths` - dispatches events with individual normal run queue lengths and a dirty
+    CPU run queue length (if dirty schedulers are available).
+
+      For normal run queues, event name
+      is `[:vm, run_queue_lengths, :normal]` and event metadata includes a single key, `:scheduler_id`,
+      with the scheduler ID of the queue. Note that number of schedulers is fixed at virtual machine
+      boot time, so the number of events emitted on each measurement is constant.
+
+      For dirty CPU run queue, the event name is `[:vm, :run_queues_length, :dirty_cpu]` and the
+      event metadata is empty.
+
   ### Default measurements
 
   When `:default` is provided as the value of `:vm_measurement` options, Poller uses `:total_memory`,
@@ -240,9 +270,10 @@ defmodule Telemetry.Poller do
     :processes_memory,
     :processes_used_memory,
     :binary_memory,
-    :ets_memory
+    :ets_memory,
+    :total_run_queue_lengths
   ]
-  @vm_memory_measurements [
+  @vm_measurements [
     :total_memory,
     :processes_memory,
     :processes_used_memory,
@@ -251,7 +282,9 @@ defmodule Telemetry.Poller do
     :atom_used_memory,
     :binary_memory,
     :code_memory,
-    :ets_memory
+    :ets_memory,
+    :total_run_queue_lengths,
+    :run_queue_lengths
   ]
 
   @type t :: GenServer.server()
@@ -453,7 +486,7 @@ defmodule Telemetry.Poller do
   end
 
   @spec parse_vm_measurement!(term()) :: measurement() | no_return()
-  defp parse_vm_measurement!(memory) when memory in @vm_memory_measurements do
+  defp parse_vm_measurement!(memory) when memory in @vm_measurements do
     vm_measurement(memory)
   end
 

--- a/lib/telemetry_poller/vm.ex
+++ b/lib/telemetry_poller/vm.ex
@@ -45,4 +45,45 @@ defmodule Telemetry.Poller.VM do
   def ets_memory() do
     Telemetry.execute([:vm, :memory, :ets], :erlang.memory(:ets))
   end
+
+  @spec total_run_queue_lengths() :: :ok
+  def total_run_queue_lengths() do
+    {otp_release, _} = Integer.parse(System.otp_release())
+
+    total =
+      if otp_release < 20 do
+        Enum.sum(:erlang.statistics(:run_queue_lengths))
+      else
+        :erlang.statistics(:total_run_queue_lengths)
+      end
+
+    Telemetry.execute(
+      [:vm, :run_queue_lengths, :total],
+      total,
+      %{}
+    )
+  end
+
+  @spec run_queue_lengths() :: :ok
+  def run_queue_lengths() do
+    individual_lengths = :erlang.statistics(:run_queue_lengths)
+    normal_schedulers_count = :erlang.system_info(:schedulers)
+
+    {normal_run_queue_lengths, dirty_run_queue_lengths} =
+      Enum.split(individual_lengths, normal_schedulers_count)
+
+    for {run_queue_length, scheduler_id} <- Enum.with_index(normal_run_queue_lengths, 1) do
+      Telemetry.execute([:vm, :run_queue_lengths, :normal], run_queue_length, %{
+        scheduler_id: scheduler_id
+      })
+    end
+
+    case dirty_run_queue_lengths do
+      [dirty_cpu_run_queue_length] ->
+        Telemetry.execute([:vm, :run_queue_lengths, :dirty_cpu], dirty_cpu_run_queue_length)
+
+      _ ->
+        :ok
+    end
+  end
 end

--- a/test/telemetry_poller/vm_test.exs
+++ b/test/telemetry_poller/vm_test.exs
@@ -101,6 +101,7 @@ defmodule Telemetry.Poller.VMTest do
     Telemetry.detach(handler_id)
   end
 
+  @tag :dirty_schedulers
   test "run_queue_lengths/0 dispatches a [:vm, :run_queue_lengths, :dirty_cpu] event with empty metadata" do
     empty_metadata = %{}
 

--- a/test/telemetry_poller/vm_test.exs
+++ b/test/telemetry_poller/vm_test.exs
@@ -76,4 +76,36 @@ defmodule Telemetry.Poller.VMTest do
       VM.ets_memory()
     end
   end
+
+  test "total_run_queue_lengths/0 dispatches [:vm, :run_queue_lengths, total] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :run_queue_lengths, :total], _, ^empty_metadata, fn ->
+      VM.total_run_queue_lengths()
+    end
+  end
+
+  test "run_queue_lengths/0 dispatches [:vm, :run_queue_lengths, :normal] event for each normal " <>
+         "run queue" do
+    normal_schedulers_count = :erlang.system_info(:schedulers)
+    event = [:vm, :run_queue_lengths, :normal]
+    handler_id = attach_to(event)
+
+    VM.run_queue_lengths()
+
+    for scheduler_id <- 1..normal_schedulers_count do
+      metadata = %{scheduler_id: scheduler_id}
+      assert_dispatched ^event, _, ^metadata
+    end
+
+    Telemetry.detach(handler_id)
+  end
+
+  test "run_queue_lengths/0 dispatches a [:vm, :run_queue_lengths, :dirty_cpu] event with empty metadata" do
+    empty_metadata = %{}
+
+    assert_dispatch [:vm, :run_queue_lengths, :dirty_cpu], _, ^empty_metadata, fn ->
+      VM.run_queue_lengths()
+    end
+  end
 end

--- a/test/telemetry_poller_test.exs
+++ b/test/telemetry_poller_test.exs
@@ -66,8 +66,7 @@ defmodule Telemetry.PollerTest do
     measurement1 = {Telemetry.Poller.VM, :memory, []}
     measurement2 = {TestMeasure, :single_sample, [[:a, :second, :test, :event], 1, %{}]}
 
-    {:ok, poller} =
-      Poller.start_link(measurements: [measurement1, measurement2])
+    {:ok, poller} = Poller.start_link(measurements: [measurement1, measurement2])
 
     measurements = Poller.list_measurements(poller)
 
@@ -114,7 +113,8 @@ defmodule Telemetry.PollerTest do
       :processes_memory,
       :processes_used_memory,
       :ets_memory,
-      :binary_memory
+      :binary_memory,
+      :total_run_queue_lengths
     ]
 
     {:ok, poller} = Poller.start_link(vm_measurements: :default)
@@ -137,7 +137,9 @@ defmodule Telemetry.PollerTest do
       :atom_used_memory,
       :binary_memory,
       :code_memory,
-      :ets_memory
+      :ets_memory,
+      :total_run_queue_lengths,
+      :run_queue_lengths
     ]
 
     {:ok, poller} = Poller.start_link(vm_measurements: vm_measurements)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,10 +1,18 @@
 elixir_vsn = System.version()
+{otp_release, _} = Integer.parse(System.otp_release())
 
-config =
+exclude =
   if Version.match?(elixir_vsn, "~> 1.5") do
     []
   else
-    [exclude: :elixir_1_5_child_specs]
+    [:elixir_1_5_child_specs]
   end
 
-ExUnit.start(config)
+exclude =
+  if otp_release < 20 do
+    [:dirty_schedulers | exclude]
+  else
+    exclude
+  end
+
+ExUnit.start(exclude: exclude)


### PR DESCRIPTION
This PR adds two new VM measurements:

- `:total_run_queue_lengths` - emits an event with a sum of run queue lengths, including dirty CPU run queue and without dirty IO run queue
- `:run_queue_lengths` - emits an event for each normal run queue and dirty CPU run queue

@josevalim I know that you were concerned with efficiency here. We are not using `erlang:statistics(run_queues)` in the implementation, which is the inefficient method of getting the run queues length (probably because it fetches the lengths atomically, so maybe some kind of locking is involved). 

Closes #7 