### PR TITLE
Remove tests for Elixir pre-1.5 features

### DIFF
--- a/test/telemetry_poller_test.exs
+++ b/test/telemetry_poller_test.exs
@@ -84,19 +84,7 @@ defmodule Telemetry.PollerTest do
     assert eventually(fn -> [] == Poller.list_measurements(poller) end)
   end
 
-  test "poller can be started under supervisor using the old-style child spec" do
-    measurement = {Telemetry.Poller.VM, :memory, []}
-    child_id = MyPoller
-    children = [Supervisor.child_spec({Poller, measurements: [measurement]}, id: child_id)]
-
-    {:ok, sup} = Supervisor.start_link(children, strategy: :one_for_one)
-
-    assert [{^child_id, poller, :worker, [Poller]}] = Supervisor.which_children(sup)
-    assert measurement in Poller.list_measurements(poller)
-  end
-
-  @tag :elixir_1_5_child_specs
-  test "poller can be started under supervisor using the new-style child spec" do
+  test "poller can be started under supervisor" do
     measurement = {Telemetry.Poller.VM, :memory, []}
     child_id = MyPoller
     children = [Supervisor.child_spec({Poller, measurements: [measurement]}, id: child_id)]

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,18 +1,10 @@
-elixir_vsn = System.version()
 {otp_release, _} = Integer.parse(System.otp_release())
 
 exclude =
-  if Version.match?(elixir_vsn, "~> 1.5") do
-    []
-  else
-    [:elixir_1_5_child_specs]
-  end
-
-exclude =
   if otp_release < 20 do
-    [:dirty_schedulers | exclude]
+    [:dirty_schedulers]
   else
-    exclude
+    []
   end
 
 ExUnit.start(exclude: exclude)


### PR DESCRIPTION
Since we run on ~> 1.5 now, we don't need to test old-style child specs.