### PR TITLE
Use a map of measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,35 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+This release marks the upgrade to Telemetry 0.4.0. This means that Poller measurements can emit a map
+of values now instead of a single one, making it less "noisy" when it comes to number of emitted events.
+
+All specific memory measurements have been replaced with a single `:memory` measurement sending all
+the values that were emitted by old measurements at once.
+
+`:run_queue_lengths` VM measurement has been removed for now, as we believe that as detailed data
+as it provided is not necessary to effectively debug the system. `:total_run_queue_lengths` VM
+measurement has been changed so that it reports a `:total` length of run queues, length of `:cpu`
+run queues (including dirty CPU run queue), and length of (dirty) `:io` run queue.
+
+### Added
+
+- `:memory` VM measurement reporting all the data returned by `:erlang.memory/0` call.
+
+### Changed
+
+- `:total_run_queue_lengths` VM measurement is reporting a `:total`, `:cpu` and `:io` run queue lengths
+  now. See documentation for more details.
+
+### Removed
+
+- `:total_memory`, `:atom_memory`, `:atom_used_memory`, `:processes_memory`, `:processes_used_memory`,
+  `:binary_memory`, `:ets_memory`, `:code_memory` and `:system_memory` VM measurements have been removed.
+  Please use the `:memory` measurement now instead.
+
 ## [0.2.0](https://github.com/beam-telemetry/telemetry_poller/tree/v0.2.0)
 
 ### Added
 
-* Added `:total_run_queue_lengths` and `:run_queue_lengths` memory measurements;
+- Added `:total_run_queue_lengths` and `:run_queue_lengths` memory measurements;
 
 ### Changed
 
-* `:total_run_queue_lengths` is now included in the set of default VM measurements;
-* A default Poller process, with a default set of VM measurements, is started when `:telemetry_poller`
+- `:total_run_queue_lengths` is now included in the set of default VM measurements;
+- A default Poller process, with a default set of VM measurements, is started when `:telemetry_poller`
   application starts (configurable via `:telemetry.poller, :default` application environment).
-* VM measurements are now provided to Poller's `:vm_measurements` option. Passing atom `:default`
+- VM measurements are now provided to Poller's `:vm_measurements` option. Passing atom `:default`
   to this option makes the Poller use a default set of VM measurements;
-* Telemetry has been upgraded to version 0.3, meaning that VM measurements now use this version to
+- Telemetry has been upgraded to version 0.3, meaning that VM measurements now use this version to
   emit the events.
 
 ### Removed
 
-* `Telemetry.Poller.vm_measurements/0` function has been removed in favor of `:vm_measurements`
+- `Telemetry.Poller.vm_measurements/0` function has been removed in favor of `:vm_measurements`
   option.
 
 ### Fixed
 
-* Fixed the type definition of `Telemetry.Poller.measurement/0` type - no Dialyzer warnings are
+- Fixed the type definition of `Telemetry.Poller.measurement/0` type - no Dialyzer warnings are
   emitted when running it on the project.
 
 ## [0.1.0](https://github.com/beam-telemetry/telemetry_poller/tree/v0.1.0)
 
 ### Added
 
-* The Poller process periodically invoking registered functions which emit Telemetry events.
+- The Poller process periodically invoking registered functions which emit Telemetry events.
   It supports VM memory measurements and custom measurements provided as MFAs.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Allows to periodically collect measurements and dispatch them as Telemetry event
 
 ```elixir
 config :telemetry_poller, :default,
-  vm_measurements: :default # or a list such as [:total_memory, :binary_memory, ...]
+  vm_measurements: :default # or a list such as [:memory, ...]
 ```
 
 Poller also provides a convenient API for specifying functions called periodically to dispatch

--- a/lib/telemetry_poller.ex
+++ b/lib/telemetry_poller.ex
@@ -12,7 +12,7 @@ defmodule Telemetry.Poller do
   But you may specify all VM measurements you want:
 
       config :telemetry_poller, :default,
-        vm_measurements: [:total_memory, :binary_memory, :total_run_queue_lengths]
+        vm_measurements: [:memory, :run_queue_lengths]
 
   Measurements are MFAs called periodically by the poller process.
   You can disable the default poller by setting it to `false`:
@@ -45,29 +45,9 @@ defmodule Telemetry.Poller do
 
   ### Memory
 
-  See documentation for `:erlang.memory/0` function for more information about
-  each type of memory measured.
-
-  * `:total_memory` - dispatches an event with total amount of currently allocated memory, in bytes.
-  Event name is `[:vm, :memory, :total]` and event metadata is empty;
-  * `:processes_memory` - dispatches an event with amount of memory cyrrently allocated for
-    processes, in bytes. Event name is `[:vm, :memory, :processes]` and event metadata is empty;
-  * `:processes_used_memory` - dispatches an event with amount of memory currently used for
-    processes, in bytes. Event name is `[:vm, :memory, :processes_used]` and event metadata is empty.
-    Memory measured is a fraction of value collected by `:processes_memory` measurement;
-  * `:binary_memory` - dispatches an event with amount of memory currently allocated for binaries.
-    Event name is `[:vm, :memory, :binary]` and event metadata is empty;
-  * `:ets_memory` - dispatches an event with amount of memory currently allocated for ETS tables.
-    Event name is `[:vm, :memory, :ets]` and event metadata is empty;
-  * `:system_memory` - dispatches an event with amount of currently allocated memory not directly
-    related to any process running in the VM, in bytes. Event name is `[:vm, :memory, :system]` and
-    event metadata is empty;
-  * `:atom_memory` - dispatches an event with amount of memory currently allocated for atoms. Event
-    name is `[:vm, :memory, :atom]` and event metadata is empty;
-  * `:atom_used_memory` - dispatches an event with amount of memory currently used for atoms. Event
-    name is `[:vm, :memory, :atom_used]` and event metadata is empty;
-  * `:code_memory` - dispatches an event with amount of memory currently allocated for code. Event
-    name is `[:vm, :memory, :code]` and event metadata is empty;
+  There is only one measurement related to memory - `:memory`. The emitted event includes all the
+  key-value pairs returned by `:erlang.memory/0` function, e.g. `:total` for total memory,
+  `:processes_used` for memory used by all processes etc.
 
   ### Run queue lengths
 
@@ -114,9 +94,8 @@ defmodule Telemetry.Poller do
 
   ### Default measurements
 
-  When `:default` is provided as the value of `:vm_measurement` options, Poller uses
-  `:total_memory`, `:processes_memory`, `:processes_used_memory`, `:binary_memory`,
-  `:ets_memory` and `:total_run_queue_lengths` VM measurements.
+  When `:default` is provided as the value of `:vm_measurement` options, Poller uses `:memory` and
+  `:total_run_queue_lengths` VM measurements.
 
   ## Example - measuring message queue length of the process
 
@@ -272,23 +251,11 @@ defmodule Telemetry.Poller do
 
   @default_period 10_000
   @default_vm_measurements [
-    :total_memory,
-    :processes_memory,
-    :processes_used_memory,
-    :binary_memory,
-    :ets_memory,
+    :memory,
     :total_run_queue_lengths
   ]
   @vm_measurements [
-    :total_memory,
-    :processes_memory,
-    :processes_used_memory,
-    :system_memory,
-    :atom_memory,
-    :atom_used_memory,
-    :binary_memory,
-    :code_memory,
-    :ets_memory,
+    :memory,
     :total_run_queue_lengths,
     :run_queue_lengths
   ]
@@ -303,15 +270,7 @@ defmodule Telemetry.Poller do
   @type period :: pos_integer()
   @type measurement() :: {module(), function :: atom(), args :: list()}
   @type vm_measurement() ::
-          :total_memory
-          | :processes_memory
-          | :processes_used_memory
-          | :system_memory
-          | :atom_memory
-          | :atom_used_memory
-          | :binary_memory
-          | :code_memory
-          | :ets_memory
+          :memory
           | :total_run_queue_lengths
           | :run_queue_lengths
 

--- a/lib/telemetry_poller/vm.ex
+++ b/lib/telemetry_poller/vm.ex
@@ -15,38 +15,21 @@ defmodule Telemetry.Poller.VM do
       if otp_release < 20 do
         Enum.sum(:erlang.statistics(:run_queue_lengths))
       else
+        :erlang.statistics(:total_run_queue_lengths_all)
+      end
+
+    cpu =
+      if otp_release < 20 do
+        # Before OTP 20.0 there were only normal run queues.
+        total
+      else
         :erlang.statistics(:total_run_queue_lengths)
       end
 
     :telemetry.execute(
-      [:vm, :run_queue_lengths, :total],
-      %{length: total},
+      [:vm, :total_run_queue_lengths],
+      %{total: total, cpu: cpu, io: total - cpu},
       %{}
     )
-  end
-
-  @spec run_queue_lengths() :: :ok
-  def run_queue_lengths() do
-    individual_lengths = :erlang.statistics(:run_queue_lengths)
-    normal_schedulers_count = :erlang.system_info(:schedulers)
-
-    {normal_run_queue_lengths, dirty_run_queue_lengths} =
-      Enum.split(individual_lengths, normal_schedulers_count)
-
-    for {run_queue_length, scheduler_id} <- Enum.with_index(normal_run_queue_lengths, 1) do
-      :telemetry.execute([:vm, :run_queue_lengths, :normal], %{length: run_queue_length}, %{
-        scheduler_id: scheduler_id
-      })
-    end
-
-    case dirty_run_queue_lengths do
-      [dirty_cpu_run_queue_length] ->
-        :telemetry.execute([:vm, :run_queue_lengths, :dirty_cpu], %{
-          length: dirty_cpu_run_queue_length
-        })
-
-      _ ->
-        :ok
-    end
   end
 end

--- a/lib/telemetry_poller/vm.ex
+++ b/lib/telemetry_poller/vm.ex
@@ -1,49 +1,10 @@
 defmodule Telemetry.Poller.VM do
   @moduledoc false
 
-  @spec total_memory() :: :ok
-  def total_memory() do
-    :telemetry.execute([:vm, :memory, :total], :erlang.memory(:total))
-  end
-
-  @spec processes_memory() :: :ok
-  def processes_memory() do
-    :telemetry.execute([:vm, :memory, :processes], :erlang.memory(:processes))
-  end
-
-  @spec processes_used_memory() :: :ok
-  def processes_used_memory() do
-    :telemetry.execute([:vm, :memory, :processes_used], :erlang.memory(:processes_used))
-  end
-
-  @spec system_memory() :: :ok
-  def system_memory() do
-    :telemetry.execute([:vm, :memory, :system], :erlang.memory(:system))
-  end
-
-  @spec atom_memory() :: :ok
-  def atom_memory() do
-    :telemetry.execute([:vm, :memory, :atom], :erlang.memory(:atom))
-  end
-
-  @spec atom_used_memory() :: :ok
-  def atom_used_memory() do
-    :telemetry.execute([:vm, :memory, :atom_used], :erlang.memory(:atom_used))
-  end
-
-  @spec binary_memory() :: :ok
-  def binary_memory() do
-    :telemetry.execute([:vm, :memory, :binary], :erlang.memory(:binary))
-  end
-
-  @spec code_memory() :: :ok
-  def code_memory() do
-    :telemetry.execute([:vm, :memory, :code], :erlang.memory(:code))
-  end
-
-  @spec ets_memory() :: :ok
-  def ets_memory() do
-    :telemetry.execute([:vm, :memory, :ets], :erlang.memory(:ets))
+  @spec memory() :: :ok
+  def memory() do
+    measurements = :erlang.memory() |> Map.new()
+    :telemetry.execute([:vm, :memory], measurements)
   end
 
   @spec total_run_queue_lengths() :: :ok
@@ -59,7 +20,7 @@ defmodule Telemetry.Poller.VM do
 
     :telemetry.execute(
       [:vm, :run_queue_lengths, :total],
-      total,
+      %{length: total},
       %{}
     )
   end
@@ -73,14 +34,16 @@ defmodule Telemetry.Poller.VM do
       Enum.split(individual_lengths, normal_schedulers_count)
 
     for {run_queue_length, scheduler_id} <- Enum.with_index(normal_run_queue_lengths, 1) do
-      :telemetry.execute([:vm, :run_queue_lengths, :normal], run_queue_length, %{
+      :telemetry.execute([:vm, :run_queue_lengths, :normal], %{length: run_queue_length}, %{
         scheduler_id: scheduler_id
       })
     end
 
     case dirty_run_queue_lengths do
       [dirty_cpu_run_queue_length] ->
-        :telemetry.execute([:vm, :run_queue_lengths, :dirty_cpu], dirty_cpu_run_queue_length)
+        :telemetry.execute([:vm, :run_queue_lengths, :dirty_cpu], %{
+          length: dirty_cpu_run_queue_length
+        })
 
       _ ->
         :ok

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Telemetry.Poller.MixProject do
 
   defp deps do
     [
-      {:telemetry, "~> 0.3"},
+      {:telemetry, "~> 0.4"},
       {:ex_doc, "~> 0.19", only: :docs},
       {:dialyxir, "~> 1.0.0-rc.1", only: :test, runtime: false},
       {:excoveralls, "~> 0.10.0", only: :test, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -15,6 +15,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
-  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/telemetry_poller/vm_test.exs
+++ b/test/telemetry_poller/vm_test.exs
@@ -26,36 +26,16 @@ defmodule Telemetry.Poller.VMTest do
                     end
   end
 
-  test "total_run_queue_lengths/0 dispatches [:vm, :run_queue_lengths, total] event with empty metadata" do
+  test "total_run_queue_lengths/0 dispatches [:vm, :run_queue_lengths] event with total, cpu and io " <>
+         "run queue lengths" do
     empty_metadata = %{}
 
-    assert_dispatch [:vm, :run_queue_lengths, :total], _, ^empty_metadata, fn ->
+    assert_dispatch [:vm, :total_run_queue_lengths], %{
+      total: _,
+      cpu: _,
+      io: _
+    }, ^empty_metadata, fn ->
       VM.total_run_queue_lengths()
-    end
-  end
-
-  test "run_queue_lengths/0 dispatches [:vm, :run_queue_lengths, :normal] event for each normal " <>
-         "run queue" do
-    normal_schedulers_count = :erlang.system_info(:schedulers)
-    event = [:vm, :run_queue_lengths, :normal]
-    handler_id = attach_to(event)
-
-    VM.run_queue_lengths()
-
-    for scheduler_id <- 1..normal_schedulers_count do
-      metadata = %{scheduler_id: scheduler_id}
-      assert_dispatched ^event, %{length: _}, ^metadata
-    end
-
-    :telemetry.detach(handler_id)
-  end
-
-  @tag :dirty_schedulers
-  test "run_queue_lengths/0 dispatches a [:vm, :run_queue_lengths, :dirty_cpu] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :run_queue_lengths, :dirty_cpu], %{length: _}, ^empty_metadata, fn ->
-      VM.run_queue_lengths()
     end
   end
 end

--- a/test/telemetry_poller/vm_test.exs
+++ b/test/telemetry_poller/vm_test.exs
@@ -5,76 +5,25 @@ defmodule Telemetry.Poller.VMTest do
 
   alias Telemetry.Poller.VM
 
-  test "total_memory/0 dispatches [:vm, :memory, :total] event with empty metadata" do
+  test "memory/0 dispatches [:vm, :memory] event with memory measurements" do
     empty_metadata = %{}
 
-    assert_dispatch [:vm, :memory, :total], _, ^empty_metadata, fn ->
-      VM.total_memory()
-    end
-  end
-
-  test "processes_memory/0 dispatches [:vm, :memory, :processes] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :processes], _, ^empty_metadata, fn ->
-      VM.processes_memory()
-    end
-  end
-
-  test "processes_used_memory/0 dispatches [:vm, :memory, :processes_used] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :processes_used], _, ^empty_metadata, fn ->
-      VM.processes_used_memory()
-    end
-  end
-
-  test "system_memory/0 dispatches [:vm, :memory, :system] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :system], _, ^empty_metadata, fn ->
-      VM.system_memory()
-    end
-  end
-
-  test "atom_memory/0 dispatches [:vm, :memory, :atom] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :atom], _, ^empty_metadata, fn ->
-      VM.atom_memory()
-    end
-  end
-
-  test "atom_used_memory/0 dispatches [:vm, :memory, :atom_used] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :atom_used], _, ^empty_metadata, fn ->
-      VM.atom_used_memory()
-    end
-  end
-
-  test "binary_memory/0 dispatches [:vm, :memory, :binary] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :binary], _, ^empty_metadata, fn ->
-      VM.binary_memory()
-    end
-  end
-
-  test "code_memory/0 dispatches [:vm, :memory, :code] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :code], _, ^empty_metadata, fn ->
-      VM.code_memory()
-    end
-  end
-
-  test "ets_memory/0 dispatches [:vm, :memory, :ets] event with empty metadata" do
-    empty_metadata = %{}
-
-    assert_dispatch [:vm, :memory, :ets], _, ^empty_metadata, fn ->
-      VM.ets_memory()
-    end
+    assert_dispatch [:vm, :memory],
+                    %{
+                      total: _,
+                      processes: _,
+                      processes_used: _,
+                      system: _,
+                      atom: _,
+                      atom_used: _,
+                      binary: _,
+                      code: _,
+                      ets: _
+                    },
+                    ^empty_metadata,
+                    fn ->
+                      VM.memory()
+                    end
   end
 
   test "total_run_queue_lengths/0 dispatches [:vm, :run_queue_lengths, total] event with empty metadata" do
@@ -95,7 +44,7 @@ defmodule Telemetry.Poller.VMTest do
 
     for scheduler_id <- 1..normal_schedulers_count do
       metadata = %{scheduler_id: scheduler_id}
-      assert_dispatched ^event, _, ^metadata
+      assert_dispatched ^event, %{length: _}, ^metadata
     end
 
     :telemetry.detach(handler_id)
@@ -105,7 +54,7 @@ defmodule Telemetry.Poller.VMTest do
   test "run_queue_lengths/0 dispatches a [:vm, :run_queue_lengths, :dirty_cpu] event with empty metadata" do
     empty_metadata = %{}
 
-    assert_dispatch [:vm, :run_queue_lengths, :dirty_cpu], _, ^empty_metadata, fn ->
+    assert_dispatch [:vm, :run_queue_lengths, :dirty_cpu], %{length: _}, ^empty_metadata, fn ->
       VM.run_queue_lengths()
     end
   end

--- a/test/telemetry_poller_test.exs
+++ b/test/telemetry_poller_test.exs
@@ -114,8 +114,7 @@ defmodule Telemetry.PollerTest do
   test "poller can be given a list of VM measurements" do
     vm_measurements = [
       :memory,
-      :total_run_queue_lengths,
-      :run_queue_lengths
+      :total_run_queue_lengths
     ]
 
     {:ok, poller} = Poller.start_link(vm_measurements: vm_measurements)

--- a/test/telemetry_poller_test.exs
+++ b/test/telemetry_poller_test.exs
@@ -7,7 +7,7 @@ defmodule Telemetry.PollerTest do
 
   defmodule TestMeasure do
     def single_sample(event, value, metadata \\ %{}),
-      do: :telemetry.execute(event, value, metadata)
+      do: :telemetry.execute(event, %{value: value}, metadata)
 
     def raise(), do: raise("I'm raising because I can!")
   end
@@ -33,8 +33,8 @@ defmodule Telemetry.PollerTest do
     ## *after* the period has passed, and not that at least two events are dispatched before one
     ## period passes.
     Process.sleep(period)
-    assert_dispatched ^event, ^value, _, 0
-    assert_dispatched ^event, ^value, _, 100
+    assert_dispatched ^event, %{value: ^value}, _, 0
+    assert_dispatched ^event, %{value: ^value}, _, 100
   end
 
   @tag :capture_log
@@ -57,7 +57,7 @@ defmodule Telemetry.PollerTest do
     metadata = %{some: "metadata"}
     measurement = {TestMeasure, :single_sample, [event, value, metadata]}
 
-    assert_dispatch event, ^value, ^metadata, fn ->
+    assert_dispatch event, %{value: ^value}, ^metadata, fn ->
       {:ok, _} = Poller.start_link(measurements: [measurement])
     end
   end
@@ -97,11 +97,7 @@ defmodule Telemetry.PollerTest do
 
   test "poller can be given :default VM measurements" do
     measurement_funs = [
-      :total_memory,
-      :processes_memory,
-      :processes_used_memory,
-      :ets_memory,
-      :binary_memory,
+      :memory,
       :total_run_queue_lengths
     ]
 
@@ -117,15 +113,7 @@ defmodule Telemetry.PollerTest do
 
   test "poller can be given a list of VM measurements" do
     vm_measurements = [
-      :total_memory,
-      :processes_memory,
-      :processes_used_memory,
-      :system_memory,
-      :atom_memory,
-      :atom_used_memory,
-      :binary_memory,
-      :code_memory,
-      :ets_memory,
+      :memory,
       :total_run_queue_lengths,
       :run_queue_lengths
     ]
@@ -143,7 +131,7 @@ defmodule Telemetry.PollerTest do
   end
 
   test "poller registers unique VM measurements" do
-    {:ok, poller} = Poller.start_link(vm_measurements: [:total_memory, :total_memory])
+    {:ok, poller} = Poller.start_link(vm_measurements: [:memory, :memory])
 
     assert 1 == length(Poller.list_measurements(poller))
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,10 +1,1 @@
-{otp_release, _} = Integer.parse(System.otp_release())
-
-exclude =
-  if otp_release < 20 do
-    [:dirty_schedulers]
-  else
-    []
-  end
-
-ExUnit.start(exclude: exclude)
+ExUnit.start()


### PR DESCRIPTION
The new `:memory` measurement emits an event with all the values available as distinct measurements previously.

I was wondering about two more things regarding upgrade to Telemetry 0.4:
- should we change the notion of "measurements" to something else? Because now we have both Poller's measurements and measurements in emitted events
- I'm not sure if and how run queue lengths measurements could benefit from Telemetry 0.4. I was thinking that maybe we could emit all run queue lengths at once, but that might be not the best idea, because the number of entries in the measurements map depends on the number of active schedulers. We don't have a written rule or a suggestion for that yet, but I have a hunch that the keys in event's measurements and metadata maps should be known up front.

The `:total_run_queue_lengths` measurement has been changed to that now it includes `:total` measurement with the sum of all run queue lengths, `:cpu` for CPU schedulers (including dirty CPU run queue) and `:io` for dirty IO scheduler.

@tsloughter I know you had some concerns regarding poller emitting too many events, is that what you were thinking about?