### PR TITLE
Document default options in README / docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ end
     {ExampleApp.Measurements, :dispatch_session_count, []},
   ],
   period: 10_000, # configure sampling period - default is 5_000
-  name: :my_app_worker_telemetry_poller # configure name - default is `:telemetry_poller`
+  name: :my_app_poller # configure name - default is `:telemetry_poller`
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ telemetry_poller:start_link(
     {process_info, [{name, my_app_worker}, {event, [my_app, worker]}, {keys, [memory, message_queue_len]}]},
     {example_app_measurements, dispatch_session_count, []}
   ]},
-  {period, 10000} % configure sampling period - default is 5000
+  {period, 10000}, % configure sampling period - default is 5000
+  {name, my_app_worker_telemetry_poller} % configure name - default is `telemetry_poller`
 ]).
 ```
 
@@ -62,7 +63,8 @@ end
     {:process_info, name: :my_app_worker, event: [:my_app, :worker], keys: [:message, :message_queue_len]},
     {ExampleApp.Measurements, :dispatch_session_count, []},
   ],
-  period: 10_000 # configure sampling period - default is 5_000
+  period: 10_000, # configure sampling period - default is 5_000
+  name: :my_app_worker_telemetry_poller # configure name - default is `:telemetry_poller`
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ telemetry_poller:start_link(
     {example_app_measurements, dispatch_session_count, []}
   ]},
   {period, 10000}, % configure sampling period - default is 5000
-  {name, my_app_worker_telemetry_poller} % configure name - default is `telemetry_poller`
+  {name, my_app_poller} % configure name - default is `telemetry_poller`
 ]).
 ```
 

--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -206,6 +206,8 @@
 %% @doc Starts a poller linked to the calling process.
 %%
 %% Useful for starting Pollers as a part of a supervision tree.
+%%
+%% Default options: [{name, telemetry_poller}, {period, 5000}]
 -spec start_link(options()) -> gen_server:on_start().
 start_link(Opts) when is_list(Opts) ->
     Name = proplists:get_value(name, Opts, ?MODULE),


### PR DESCRIPTION
Failing to specify this will result in the default `:telemetry_poller` being used, so it would be good to mention in the README and the docs that this is a thing.