### PR TITLE
Add built-in `system_limits` measurement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,3 @@ workflows:
       - telemetry_poller/build_and_test:
           name: "otp-20"
           version: "20"
-      - telemetry_poller/build_and_test:
-          name: "otp-19"
-          version: "19"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Allows to periodically collect measurements and dispatch them as Telemetry event
 
   * `[vm, memory]` - contains the total memory, process memory, and all other keys in `erlang:memory/0`
   * `[vm, total_run_queue_lengths]` - returns the run queue lengths for CPU and IO schedulers. It contains the `total`, `cpu` and `io` measurements
+  * `[vm, system_limits]` - returns the current process, atom and port count as per `erlang:system_info/1`
 
 You can directly consume those events after adding `telemetry_poller` as a dependency.
 

--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -17,12 +17,13 @@
 %%
 %%  * `memory' (default)
 %%  * `total_run_queue_lengths' (default)
+%%  * `system_limits' (default)
 %%  * `{process_info, Proplist}'
 %%  * `{Module, Function, Args}'
 %%
 %% We will discuss each measurement in detail. Also note that the
 %% telemetry_poller application ships with a built-in poller that
-%% measures both `memory' and `total_run_queue_lengths'. This takes
+%% measures `memory', `total_run_queue_lengths' and `system_limits'. This takes
 %% the VM measurement out of the way so your application can focus
 %% on what is specific to its behaviour.
 %%
@@ -64,6 +65,19 @@
 %% does not represent a consistent snapshot of the run queues' state.
 %% However, the value is accurate enough to help to identify issues in a
 %% running system.
+%%
+%% == System limits ==
+%%
+%% An event emitted as `[vm, system_limits]'. The event contains no metadata
+%% and three measurements:
+%%
+%% <ul>
+%% <li>`process_count' - number of process currently existing at the local node</li>
+%% <li>`atom_count' - number of atoms currently existing at the local node</li>
+%% <li>`port_count' - number of ports currently existing at the local node</li>
+%% </ul>
+%% 
+%% All three measurements are from {@link erlang:system_info/1}.
 %%
 %% == Process info ==
 %%
@@ -198,6 +212,7 @@
 -type measurement() ::
     memory
     | total_run_queue_lengths
+    | system_limits
     | {process_info, [{name, atom()} | {event, [atom()]} | {keys, [atom()]}]}
     | {module(), atom(), list()}.
 -type period() :: pos_integer().
@@ -274,6 +289,8 @@ parse_measurement(memory) ->
     {telemetry_poller_builtin, memory, []};
 parse_measurement(total_run_queue_lengths) ->
     {telemetry_poller_builtin, total_run_queue_lengths, []};
+parse_measurement(system_limits) ->
+    {telemetry_poller_builtin, system_limits, []};
 parse_measurement({process_info, List}) when is_list(List) ->
     Name = case proplists:get_value(name, List) of
         undefined -> erlang:error({badarg, "Expected `name' key to be given under process_info measurement"});

--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -17,13 +17,13 @@
 %%
 %%  * `memory' (default)
 %%  * `total_run_queue_lengths' (default)
-%%  * `system_limits' (default)
+%%  * `system_counts' (default)
 %%  * `{process_info, Proplist}'
 %%  * `{Module, Function, Args}'
 %%
 %% We will discuss each measurement in detail. Also note that the
 %% telemetry_poller application ships with a built-in poller that
-%% measures `memory', `total_run_queue_lengths' and `system_limits'. This takes
+%% measures `memory', `total_run_queue_lengths' and `system_counts'. This takes
 %% the VM measurement out of the way so your application can focus
 %% on what is specific to its behaviour.
 %%
@@ -66,9 +66,9 @@
 %% However, the value is accurate enough to help to identify issues in a
 %% running system.
 %%
-%% == System limits ==
+%% == System counts ==
 %%
-%% An event emitted as `[vm, system_limits]'. The event contains no metadata
+%% An event emitted as `[vm, system_counts]'. The event contains no metadata
 %% and three measurements:
 %%
 %% <ul>
@@ -212,7 +212,7 @@
 -type measurement() ::
     memory
     | total_run_queue_lengths
-    | system_limits
+    | system_counts
     | {process_info, [{name, atom()} | {event, [atom()]} | {keys, [atom()]}]}
     | {module(), atom(), list()}.
 -type period() :: pos_integer().
@@ -289,8 +289,8 @@ parse_measurement(memory) ->
     {telemetry_poller_builtin, memory, []};
 parse_measurement(total_run_queue_lengths) ->
     {telemetry_poller_builtin, total_run_queue_lengths, []};
-parse_measurement(system_limits) ->
-    {telemetry_poller_builtin, system_limits, []};
+parse_measurement(system_counts) ->
+    {telemetry_poller_builtin, system_counts, []};
 parse_measurement({process_info, List}) when is_list(List) ->
     Name = case proplists:get_value(name, List) of
         undefined -> erlang:error({badarg, "Expected `name' key to be given under process_info measurement"});

--- a/src/telemetry_poller_app.erl
+++ b/src/telemetry_poller_app.erl
@@ -9,7 +9,7 @@ start(_StartType, _StartArgs) ->
     PollerOpts = application:get_env(telemetry_poller, default, []),
     Default = #{
         name => telemetry_poller_default,
-        measurements => [memory, total_run_queue_lengths, system_limits]
+        measurements => [memory, total_run_queue_lengths, system_counts]
     },
     FinalOpts = maps:merge(Default, maps:from_list(PollerOpts)),
     telemetry_poller_sup:start_link(maps:to_list(FinalOpts)).

--- a/src/telemetry_poller_app.erl
+++ b/src/telemetry_poller_app.erl
@@ -9,7 +9,7 @@ start(_StartType, _StartArgs) ->
     PollerOpts = application:get_env(telemetry_poller, default, []),
     Default = #{
         name => telemetry_poller_default,
-        measurements => [memory, total_run_queue_lengths]
+        measurements => [memory, total_run_queue_lengths, system_limits]
     },
     FinalOpts = maps:merge(Default, maps:from_list(PollerOpts)),
     telemetry_poller_sup:start_link(maps:to_list(FinalOpts)).

--- a/src/telemetry_poller_builtin.erl
+++ b/src/telemetry_poller_builtin.erl
@@ -3,7 +3,7 @@
 -export([
   memory/0,
   total_run_queue_lengths/0,
-  system_limits/0,
+  system_counts/0,
   process_info/3
 ]).
 
@@ -33,12 +33,12 @@ total_run_queue_lengths() ->
         io => Total - CPU},
         #{}).
 
--spec system_limits() -> ok.
-system_limits() ->
+-spec system_counts() -> ok.
+system_counts() ->
     ProcessCount = erlang:system_info(process_count),
     AtomCount = erlang:system_info(atom_count),
     PortCount = erlang:system_info(port_count),
-    telemetry:execute([vm, system_limits], #{
+    telemetry:execute([vm, system_counts], #{
         process_count => ProcessCount,
         atom_count => AtomCount,
         port_count => PortCount

--- a/src/telemetry_poller_builtin.erl
+++ b/src/telemetry_poller_builtin.erl
@@ -3,6 +3,7 @@
 -export([
   memory/0,
   total_run_queue_lengths/0,
+  system_limits/0,
   process_info/3
 ]).
 
@@ -31,6 +32,17 @@ total_run_queue_lengths() ->
         cpu => CPU,
         io => Total - CPU},
         #{}).
+
+-spec system_limits() -> ok.
+system_limits() ->
+    ProcessCount = erlang:system_info(process_count),
+    AtomCount = erlang:system_info(atom_count),
+    PortCount = erlang:system_info(port_count),
+    telemetry:execute([vm, system_limits], #{
+        process_count => ProcessCount,
+        atom_count => AtomCount,
+        port_count => PortCount
+    }).
 
 -ifdef(OTP19).
     -spec cpu_stats(total | cpu) -> non_neg_integer().

--- a/test/telemetry_poller_SUITE.erl
+++ b/test/telemetry_poller_SUITE.erl
@@ -11,6 +11,7 @@ all() -> [
   dispatches_custom_mfa,
   dispatches_memory,
   dispatches_process_info,
+  dispatches_system_limits,
   dispatches_total_run_queue_lengths,
   doesnt_start_given_invalid_measurements,
   doesnt_start_given_invalid_period,
@@ -95,6 +96,18 @@ dispatches_total_run_queue_lengths(_Config) ->
   HandlerId = attach_to([vm, total_run_queue_lengths]),
   receive
     {event, [vm, total_run_queue_lengths], #{total := _, cpu := _, io := _}, _} ->
+      telemetry:detach(HandlerId),
+      ?assert(true)
+  after
+      1000 ->
+          ct:fail(timeout_receive_echo)
+  end.
+
+dispatches_system_limits(_Config) ->
+  {ok, _Poller} = telemetry_poller:start_link([{measurements, [system_limits]},{period, 100}]),
+  HandlerId = attach_to([vm, system_limits]),
+  receive
+    {event, [vm, system_limits], #{process_count := _, atom_count := _, port_count := _}, _} ->
       telemetry:detach(HandlerId),
       ?assert(true)
   after

--- a/test/telemetry_poller_SUITE.erl
+++ b/test/telemetry_poller_SUITE.erl
@@ -11,7 +11,7 @@ all() -> [
   dispatches_custom_mfa,
   dispatches_memory,
   dispatches_process_info,
-  dispatches_system_limits,
+  dispatches_system_counts,
   dispatches_total_run_queue_lengths,
   doesnt_start_given_invalid_measurements,
   doesnt_start_given_invalid_period,
@@ -103,11 +103,11 @@ dispatches_total_run_queue_lengths(_Config) ->
           ct:fail(timeout_receive_echo)
   end.
 
-dispatches_system_limits(_Config) ->
-  {ok, _Poller} = telemetry_poller:start_link([{measurements, [system_limits]},{period, 100}]),
-  HandlerId = attach_to([vm, system_limits]),
+dispatches_system_counts(_Config) ->
+  {ok, _Poller} = telemetry_poller:start_link([{measurements, [system_counts]},{period, 100}]),
+  HandlerId = attach_to([vm, system_counts]),
   receive
-    {event, [vm, system_limits], #{process_count := _, atom_count := _, port_count := _}, _} ->
+    {event, [vm, system_counts], #{process_count := _, atom_count := _, port_count := _}, _} ->
       telemetry:detach(HandlerId),
       ?assert(true)
   after


### PR DESCRIPTION
This event includes `process_count`, `atom_count` and `port_count`.
Closes #36.