### PR TITLE
Use timer in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ telemetry_poller:start_link(
     {process_info, [{name, my_app_worker}, {event, [my_app, worker]}, {keys, [memory, message_queue_len]}]},
     {example_app_measurements, dispatch_session_count, []}
   ]},
-  {period, 10000}, % configure sampling period - default is 5000
+  {period, timer:seconds(10)}, % configure sampling period - default is timer:seconds(5)
   {name, my_app_poller}
 ]).
 ```
@@ -64,7 +64,7 @@ end
     {:process_info, name: :my_app_worker, event: [:my_app, :worker], keys: [:message, :message_queue_len]},
     {ExampleApp.Measurements, :dispatch_session_count, []},
   ],
-  period: 10_000, # configure sampling period - default is 5_000
+  period: :timer.seconds(10), # configure sampling period - default is :timer.seconds(5)
   name: :my_app_poller
 )
 ```

--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -217,7 +217,7 @@
 %%
 %% Useful for starting Pollers as a part of a supervision tree.
 %%
-%% Default options: [{name, telemetry_poller}, {period, 5000}]
+%% Default options: [{name, telemetry_poller}, {period, timer:seconds(5)}]
 -spec start_link(options()) -> gen_server:on_start().
 start_link(Opts) when is_list(Opts) ->
     Args = parse_args(Opts),
@@ -259,7 +259,7 @@ child_spec(Opts) ->
 parse_args(Args) ->
     Measurements = proplists:get_value(measurements, Args, []),
     ParsedMeasurements = parse_measurements(Measurements),
-    Period = proplists:get_value(period, Args, 5000),
+    Period = proplists:get_value(period, Args, timer:seconds(5)),
     validate_period(Period),
     #{measurements => ParsedMeasurements, period => Period}.
 


### PR DESCRIPTION
This may be a pet-peeve of mine, but using the timer module is a bit clearer, IMO, and helps promote a better practice for the community.