### PR TITLE
Support gen_server:name() option

### DIFF
--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -223,7 +223,8 @@ start_link(Opts) when is_list(Opts) ->
     Args = parse_args(Opts),
 
     case lists:keyfind(name, 1, Opts) of
-        {name, Name} -> gen_server:start_link({local, Name}, ?MODULE, Args, []);
+        {name, Name} when is_atom(Name) -> gen_server:start_link({local, Name}, ?MODULE, Args, []);
+        {name, Name} -> gen_server:start_link(Name, ?MODULE, Args, []);
         false -> gen_server:start_link(?MODULE, Args, [])
     end.
 

--- a/test/telemetry_poller_SUITE.erl
+++ b/test/telemetry_poller_SUITE.erl
@@ -7,6 +7,7 @@
 
 all() -> [
   accepts_name_opt,
+  accepts_global_name_opt,
   can_configure_sampling_period,
   dispatches_custom_mfa,
   dispatches_memory,
@@ -31,6 +32,12 @@ accepts_name_opt(_Config) ->
   Name = my_poller,
   {ok, Pid} = telemetry_poller:start_link([{name, Name}]),
   FoundPid = erlang:whereis(Name),
+  FoundPid = Pid.
+
+accepts_global_name_opt(_Config) ->
+  Name = my_poller,
+  {ok, Pid} = telemetry_poller:start_link([{name, {global, Name}}]),
+  FoundPid = global:whereis_name(Name),
   FoundPid = Pid.
 
 multiple_unnamed(_Config) ->
@@ -138,3 +145,4 @@ attach_to(Event) ->
   HandlerId = make_ref(),
   telemetry:attach(HandlerId, Event, fun test_handler:echo_event/4, #{caller => erlang:self()}),
   HandlerId.
+


### PR DESCRIPTION
I was attempting to use `name: {:via, Registry, term}` to scope some of my pollers, but it resulted in this error:

```elixir
defmodule DHT.Telemetry do
...

  def poll(pin, sensor, period \\ 2) do
    opts = [
      measurements: [{__MODULE__, :poll_read, [pin, sensor]}],
      period: :timer.seconds(period),
      name: {:via, Registry, {Pollers, "#{pin}-#{sensor}"}}
    ]

    DynamicSupervisor.start_child(__MODULE__, {:telemetry_poller, opts})
  end

...
end

iex(1)> DHT.Telemetry.poll 11, 11                     
{:error,
 {:badarg,
  [
    {:erlang, :whereis, [{:via, Registry, {Pollers, {11, 11}}}], []},
    {:gen, :where, 1, [file: 'gen.erl', line: 265]},
    {:gen, :start, 6, [file: 'gen.erl', line: 76]},
    {DynamicSupervisor, :start_child, 3,
     [file: 'lib/dynamic_supervisor.ex', line: 692]},
    {DynamicSupervisor, :handle_start_child, 2,
     [file: 'lib/dynamic_supervisor.ex', line: 678]},
    {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]},
    {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]},
    {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}
  ]}}
```

Upon inspection, the spec says the `name` option supports `gen_server:name()` type, but it was taking any supplied name and making it `{local, Name}`. In my case, that effectively turned into `{local, {via, Registry, term}}`, which is invalid.

So this fixes the `start_link/1` to support all the available types of `gen_server:name()` by only using `{local, Name}` if the option is an atom, and passing all other `Name` option values directly to start_link