### PR TITLE
Fix dialyzer issue with start_link/1 option()

### DIFF
--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -201,7 +201,7 @@
 -type t() :: gen_server:server().
 -type options() :: [option()].
 -type option() ::
-    {name, atom() | {global, atom()} | {via, module(), term()}}
+    {name, gen_server:name() | gen_server:server_name()}
     | {period, period()}
     | {measurements, [measurement()]}.
 -type measurement() ::

--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -201,7 +201,7 @@
 -type t() :: gen_server:server().
 -type options() :: [option()].
 -type option() ::
-    {name, atom() | {global, atom()}, {via, module(), term()}}
+    {name, atom() | {global, atom()} | {via, module(), term()}}
     | {period, period()}
     | {measurements, [measurement()]}.
 -type measurement() ::


### PR DESCRIPTION
The name option was improperly typed, this should fix it. This was a real head-scratcher. Big thanks to `no local return` for pinpointing this one ;)