### PR TITLE
Fix disabling of the default poller

### DIFF
--- a/src/telemetry_poller_app.erl
+++ b/src/telemetry_poller_app.erl
@@ -6,13 +6,19 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
-    PollerOpts = application:get_env(telemetry_poller, default, []),
-    Default = #{
-        name => telemetry_poller_default,
-        measurements => [memory, total_run_queue_lengths, system_counts]
-    },
-    FinalOpts = maps:merge(Default, maps:from_list(PollerOpts)),
-    telemetry_poller_sup:start_link(maps:to_list(FinalOpts)).
+    PollerChildSpec =
+        case application:get_env(telemetry_poller, default, []) of
+            false ->
+                [];
+            PollerOpts ->
+                Default = #{
+                            name => telemetry_poller_default,
+                            measurements => [memory, total_run_queue_lengths, system_counts]
+                           },
+                FinalOpts = maps:to_list(maps:merge(Default, maps:from_list(PollerOpts))),
+                [telemetry_poller:child_spec(FinalOpts)]
+        end,
+    telemetry_poller_sup:start_link(PollerChildSpec).
 
 stop(_State) ->
     ok.

--- a/src/telemetry_poller_sup.erl
+++ b/src/telemetry_poller_sup.erl
@@ -8,12 +8,11 @@
 
 -define(SERVER, ?MODULE).
 
-start_link(Opts) ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, Opts).
+start_link(PollerChildSpec) ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, PollerChildSpec).
 
-init(Opts) ->
+init(PollerChildSpec) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 1,
                  period => 5},
-    PollerChildSpec = telemetry_poller:child_spec(Opts),
-    {ok, {SupFlags, [PollerChildSpec]}}.
+    {ok, {SupFlags, PollerChildSpec}}.


### PR DESCRIPTION
Docs state that to disable default poller you need to set app's environment key `default` to _false_, but it looks like this functionality was overlooked when translating from Elixir to Erlang. This PR fixes that.