### PR TITLE
New initial_delay configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ telemetry_poller:start_link(
     {example_app_measurements, dispatch_session_count, []}
   ]},
   {period, timer:seconds(10)}, % configure sampling period - default is timer:seconds(5)
+  {initial_delay, timer:seconds(5)}, % configure initial delay - default is timer:seconds(0), i.e. no initial delay
   {name, my_app_poller}
 ]).
 ```
@@ -64,6 +65,7 @@ end
     {ExampleApp.Measurements, :dispatch_session_count, []},
   ],
   period: :timer.seconds(10), # configure sampling period - default is :timer.seconds(5)
+  initial_delay: :timer.seconds(5), # configure initial delay - default is :timer.seconds(0)
   name: :my_app_poller
 )
 ```

--- a/test/telemetry_poller_SUITE.erl
+++ b/test/telemetry_poller_SUITE.erl
@@ -10,6 +10,7 @@ all() -> [
   accepts_global_name_opt,
   dont_start_when_default_false,
   can_configure_sampling_period,
+  can_configure_initial_delay,
   dispatches_custom_mfa,
   dispatches_memory,
   dispatches_process_info,
@@ -17,6 +18,7 @@ all() -> [
   dispatches_total_run_queue_lengths,
   doesnt_start_given_invalid_measurements,
   doesnt_start_given_invalid_period,
+  doesnt_start_given_invalid_inital_delay,
   measurements_can_be_listed,
   measurement_removed_if_it_raises,
   multiple_unnamed
@@ -59,12 +61,21 @@ can_configure_sampling_period(_Config) ->
   State = sys:get_state(Pid),
   Period = maps:get(period, State).
 
+can_configure_initial_delay(_Config) ->
+  InitialDelay = 500,
+  {ok, Pid} = telemetry_poller:start_link([{measurements, []}, {initial_delay, InitialDelay}]),
+  State = sys:get_state(Pid),
+  InitialDelay = maps:get(initial_delay, State).
+
 doesnt_start_given_invalid_period(_Config) ->
   ?assertError({badarg, "Expected period to be a positive integer"},  telemetry_poller:start_link([{measurements, []}, {period, "1"}])).
 
 doesnt_start_given_invalid_measurements(_Config) ->
   ?assertError({badarg, "Expected measurement " ++ _}, telemetry_poller:start_link([{measurements, [invalid_measurement]}])),
   ?assertError({badarg, "Expected measurements to be a list"}, telemetry_poller:start_link([{measurements, {}}])).
+
+doesnt_start_given_invalid_inital_delay(_Config) ->
+  ?assertError({badarg, "Expected initial_delay to be a positive integer"},  telemetry_poller:start_link([{measurements, []}, {initial_delay, "1"}])).
 
 measurements_can_be_listed(_Config) ->
   Measurement1 = {telemetry_poller_builtin, memory, []},


### PR DESCRIPTION
This PR introduces a new `initial_delay` configuration option.

This way, we have the option to not schedule work immediately, but rather after a configured delay. This new setting is completely optional, and if not specified, the existing "no delay" (0 seconds) default will still be used.

This is especially useful for example when we don't have full control of where in a supervision tree polling metrics are configured. Having a configurable initial delay would allow for the poller to be added "up" in a supervision tree, even if polling metrics are provided by services that haven't been initialised yet. 