### PR TITLE
Use SPDX ID for licenses in mixfile

### DIFF
--- a/src/telemetry_poller.app.src
+++ b/src/telemetry_poller.app.src
@@ -10,7 +10,7 @@
    ]},
   {env,[]},
   {modules, []},
-  {licenses, ["Apache 2.0"]},
+  {licenses, ["Apache-2.0"]},
   {doc, "doc"},
   {links, [{"GitHub", "https://github.com/beam-telemetry/telemetry_poller"}]}
  ]}.


### PR DESCRIPTION
Hex.pm recommends this, and it helps tools identify exactly which license this project is released under.