### PR TITLE
Add init_delay to startup args

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ telemetry_poller:start_link(
     {example_app_measurements, dispatch_session_count, []}
   ]},
   {period, timer:seconds(10)}, % configure sampling period - default is timer:seconds(5)
+  {init_delay, timer:seconds(600)}, % configure sampling initial delay - default is 0
   {name, my_app_poller}
 ]).
 ```
@@ -56,6 +57,7 @@ children = [
      {ExampleApp.Measurements, :dispatch_session_count, []},
    ],
    period: :timer.seconds(10), # configure sampling period - default is :timer.seconds(5)
+   init_delay: :timer.seconds(600), # configure sampling initial delay - default is 0
    name: :my_app_poller}
 ]
 

--- a/test/telemetry_poller_SUITE.erl
+++ b/test/telemetry_poller_SUITE.erl
@@ -17,6 +17,7 @@ all() -> [
   dispatches_total_run_queue_lengths,
   doesnt_start_given_invalid_measurements,
   doesnt_start_given_invalid_period,
+  doesnt_start_given_invalid_init_delay,
   measurements_can_be_listed,
   measurement_removed_if_it_raises,
   multiple_unnamed
@@ -55,12 +56,16 @@ multiple_unnamed(_Config) ->
 
 can_configure_sampling_period(_Config) ->
   Period = 500,
-  {ok, Pid} = telemetry_poller:start_link([{measurements, []}, {period, Period}]),
+  {ok, Pid} = telemetry_poller:start_link([{measurements, []}, {period, Period}, {init_delay, 0}]),
   State = sys:get_state(Pid),
   Period = maps:get(period, State).
 
 doesnt_start_given_invalid_period(_Config) ->
   ?assertError({badarg, "Expected period to be a positive integer"},  telemetry_poller:start_link([{measurements, []}, {period, "1"}])).
+
+doesnt_start_given_invalid_init_delay(_Config) ->
+  ?assertError({badarg, "Expected init_delay to be 0 or a positive integer"},
+               telemetry_poller:start_link([{measurements, []}, {init_delay, "1"}])).
 
 doesnt_start_given_invalid_measurements(_Config) ->
   ?assertError({badarg, "Expected measurement " ++ _}, telemetry_poller:start_link([{measurements, [invalid_measurement]}])),


### PR DESCRIPTION
Introducing an optional startup delay argument, which specifies a time delay in milliseconds before commencing measurements, would be beneficial. This option proves valuable in scenarios where reporting cache measurements is desired, but the cache is typically empty during the application's initial startup phase.