### PR TITLE
Report system limits (atom, port, process limits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Allows to periodically collect measurements and dispatch them as Telemetry event
 
   * `[vm, memory]` - contains the total memory, process memory, and all other keys in `erlang:memory/0`
   * `[vm, total_run_queue_lengths]` - returns the run queue lengths for CPU and IO schedulers. It contains the `total`, `cpu` and `io` measurements
-  * `[vm, system_counts]` - returns the current process, atom and port count as per `erlang:system_info/1`
+  * `[vm, system_counts]` - returns the current process, atom and port count as well as their respective limits as per `erlang:system_info/1`
   * `[vm, persistent_term]` - number of terms and memory byte size for `persistent_term`
 
 You can directly consume those events after adding `telemetry_poller` as a dependency.

--- a/examples/TelemetryPollerVM.ex
+++ b/examples/TelemetryPollerVM.ex
@@ -64,7 +64,10 @@ defmodule TelemetryPollerVM do
         "-------------\n" <>
         "  atom_count: #{event_measurements.atom_count}\n" <>
         "  port_count: #{event_measurements.port_count}\n" <>
-        "  process_count: #{event_measurements.process_count}\n"
+        "  process_count: #{event_measurements.process_count}\n" <>
+        "  atom_limit: #{event_measurements.atom_limit}\n" <>
+        "  port_limit: #{event_measurements.port_limit}\n" <>
+        "  process_limit: #{event_measurements.process_limit}\n"
     )
   end
 end

--- a/examples/telemetry_poller_vm.erl
+++ b/examples/telemetry_poller_vm.erl
@@ -77,7 +77,10 @@ handle([vm, system_counts], EventMeasurements, _EventMetadata, _HandlerConfig) -
     #{
         atom_count := AtomCount,
         port_count := PortCount,
-        process_count := ProcessCount
+        process_count := ProcessCount,
+        atom_limit := AtomLimit,
+        port_limit := PortLimit,
+        process_limit := ProcessLimit
     } = EventMeasurements,
     % Do something with the measurements
     io:format(
@@ -85,10 +88,16 @@ handle([vm, system_counts], EventMeasurements, _EventMetadata, _HandlerConfig) -
         "-------------~n"
         "  atom_count: ~p~n"
         "  port_count: ~p~n"
-        "  process_count: ~p~n~n",
+        "  process_count: ~p~n"
+        "  atom_limit: ~p~n"
+        "  port_limit: ~p~n"
+        "  process_limit: ~p~n~n",
         [
             AtomCount,
             PortCount,
-            ProcessCount
+            ProcessCount,
+            AtomLimit,
+            PortLimit,
+            ProcessLimit
         ]
     ).

--- a/src/telemetry_poller.erl
+++ b/src/telemetry_poller.erl
@@ -83,6 +83,9 @@ The measurement includes:
   * `process_count` - the number of processes currently existing at the local node
   * `atom_count` - the number of atoms currently existing at the local node
   * `port_count` - the number of ports currently existing at the local node
+  * `process_limit` - the maximum number of processes allowed at the local node
+  * `atom_limit` - the maximum number of atoms allowed at the local node
+  * `port_limit` - the maximum number of ports allowed at the local node
 
 ### Persistent term (since 1.2.0)
 

--- a/src/telemetry_poller_builtin.erl
+++ b/src/telemetry_poller_builtin.erl
@@ -46,10 +46,16 @@ system_counts() ->
     ProcessCount = erlang:system_info(process_count),
     AtomCount = erlang:system_info(atom_count),
     PortCount = erlang:system_info(port_count),
+    ProcessLimit = erlang:system_info(process_limit),
+    AtomLimit = erlang:system_info(atom_limit),
+    PortLimit = erlang:system_info(port_limit),
     telemetry:execute([vm, system_counts], #{
         process_count => ProcessCount,
         atom_count => AtomCount,
-        port_count => PortCount
+        port_count => PortCount,
+        process_limit => ProcessLimit,
+        atom_limit => AtomLimit,
+        port_limit => PortLimit
     }).
 
 -spec persistent_term() -> ok.

--- a/test/telemetry_poller_SUITE.erl
+++ b/test/telemetry_poller_SUITE.erl
@@ -128,7 +128,8 @@ dispatches_system_counts(_Config) ->
   {ok, _Poller} = telemetry_poller:start_link([{measurements, [system_counts]},{period, 100}]),
   HandlerId = attach_to([vm, system_counts]),
   receive
-    {event, [vm, system_counts], #{process_count := _, atom_count := _, port_count := _}, _} ->
+    {event, [vm, system_counts], #{process_count := _, atom_count := _, port_count := _,
+                                   process_limit := _, atom_limit := _, port_limit := _}, _} ->
       telemetry:detach(HandlerId),
       ?assert(true)
   after


### PR DESCRIPTION
It's useful to report the atom, port, and process limits in addition to the current counts so that alerts can be set when we're close to reaching the limit.

This PR enhances the VM measurements by adding `vm.system_limits`, which has the same measurements as `vm.system_counts` but with the current limit values rather than the current counts.

I'm happy to remove it from the default measurements, if it'd be better to opt in for them.